### PR TITLE
z-image-turbo: update Controlnet Union 2.1

### DIFF
--- a/src/content/en/basic-workflows/z-image-turbo.md
+++ b/src/content/en/basic-workflows/z-image-turbo.md
@@ -67,21 +67,20 @@ A ControlNet-style patch for Z-Image-Turbo.
 
 - model_patches
 
-  - [Z-Image-Turbo-Fun-Controlnet-Union.safetensors](https://huggingface.co/alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union/blob/main/Z-Image-Turbo-Fun-Controlnet-Union.safetensors)
+  - [Z-Image-Turbo-Fun-Controlnet-Union-2.1.safetensors](https://huggingface.co/alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.0/blob/main/Z-Image-Turbo-Fun-Controlnet-Union-2.1.safetensors)
 
 ```text
 📂ComfyUI/
 └── 📂models/
     └── 📂model_patches/
-        └── Z-Image-Turbo-Fun-Controlnet-Union.safetensors
+        └── Z-Image-Turbo-Fun-Controlnet-Union-2.1.safetensors
 ```
 
 ### workflow
 
-![](https://gyazo.com/0e836d2ee27441ac65a66ec87a5bfb17){gyazo=image}
+![](https://gyazo.com/53c91fd9eeb8f94357b20839e5d8c967){gyazo=image}
 
-[](/workflows/basic-workflows/z-image-turbo/Z-Image-Turbo-Fun-Controlnet-Union.json)
+[](/workflows/basic-workflows/z-image-turbo/Z-Image-Turbo-Fun-Controlnet-Union-2.1.json)
 
 - 🟩 Add model and control image to `QwenImageDiffsynthControlnet`.
 - 🟩 In this workflow, Depth Anything V2 is used to create a depth map.
-- Compared to existing ControlNet, the effect seems slightly modest.

--- a/src/content/ja/basic-workflows/z-image-turbo.md
+++ b/src/content/ja/basic-workflows/z-image-turbo.md
@@ -67,21 +67,20 @@ Z-Image-Turbo 用の ControlNet 風パッチです。
 
 - model_patches
 
-  - [Z-Image-Turbo-Fun-Controlnet-Union.safetensors](https://huggingface.co/alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union/blob/main/Z-Image-Turbo-Fun-Controlnet-Union.safetensors)
+  - [Z-Image-Turbo-Fun-Controlnet-Union-2.1.safetensors](https://huggingface.co/alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.0/blob/main/Z-Image-Turbo-Fun-Controlnet-Union-2.1.safetensors)
 
 ```text
 📂ComfyUI/
 └── 📂models/
     └── 📂model_patches/
-        └── Z-Image-Turbo-Fun-Controlnet-Union.safetensors
+        └── Z-Image-Turbo-Fun-Controlnet-Union-2.1.safetensors
 ```
 
 ### workflow
 
-![](https://gyazo.com/0e836d2ee27441ac65a66ec87a5bfb17){gyazo=image}
+![](https://gyazo.com/53c91fd9eeb8f94357b20839e5d8c967){gyazo=image}
 
-[](/workflows/basic-workflows/z-image-turbo/Z-Image-Turbo-Fun-Controlnet-Union.json)
+[](/workflows/basic-workflows/z-image-turbo/Z-Image-Turbo-Fun-Controlnet-Union-2.1.json)
 
 - 🟩 `QwenImageDiffsynthControlnet` にモデルと制御画像を追加
 - 🟩 この workflow では Depth Anything V2 で深度マップを作成します。
-- 既存の ControlNet と比べると、効きの強さはやや控えめな印象です。

--- a/src/workflows/basic-workflows/z-image-turbo/Z-Image-Turbo-Fun-Controlnet-Union-2.1.json
+++ b/src/workflows/basic-workflows/z-image-turbo/Z-Image-Turbo-Fun-Controlnet-Union-2.1.json
@@ -128,29 +128,6 @@
       ]
     },
     {
-      "id": 55,
-      "type": "MarkdownNote",
-      "pos": [
-        -60.09132385253906,
-        -2.4022865295410156
-      ],
-      "size": [
-        349.13103718118725,
-        214.5148968572393
-      ],
-      "flags": {},
-      "order": 1,
-      "mode": 0,
-      "inputs": [],
-      "outputs": [],
-      "properties": {},
-      "widgets_values": [
-        "## models\n- [z_image_turbo_bf16.safetensors](https://huggingface.co/Comfy-Org/z_image_turbo/blob/main/split_files/diffusion_models/z_image_turbo_bf16.safetensors)\n- [qwen_3_4b.safetensors](https://huggingface.co/Comfy-Org/z_image_turbo/blob/main/split_files/text_encoders/qwen_3_4b.safetensors)\n- [ae.safetensors](https://huggingface.co/Comfy-Org/z_image_turbo/blob/main/split_files/vae/ae.safetensors)\n\n```\n📂ComfyUI/\n└── 📂models/\n      ├── 📂diffusion_models/\n      │   └── z_image_turbo_bf16.safetensors\n      ├── 📂text_encoders/\n      │   └── qwen_3_4b.safetensors\n      └── 📂vae/\n           └── ae.safetensors\n```"
-      ],
-      "color": "#432",
-      "bgcolor": "#653"
-    },
-    {
       "id": 37,
       "type": "UNETLoader",
       "pos": [
@@ -162,7 +139,7 @@
         82
       ],
       "flags": {},
-      "order": 2,
+      "order": 1,
       "mode": 0,
       "inputs": [],
       "outputs": [
@@ -269,7 +246,7 @@
         533.241
       ],
       "flags": {},
-      "order": 3,
+      "order": 2,
       "mode": 0,
       "inputs": [],
       "outputs": [
@@ -380,7 +357,7 @@
         58
       ],
       "flags": {},
-      "order": 4,
+      "order": 3,
       "mode": 0,
       "inputs": [],
       "outputs": [
@@ -444,41 +421,6 @@
       ]
     },
     {
-      "id": 58,
-      "type": "ModelPatchLoader",
-      "pos": [
-        622.8999606619018,
-        482.9956856718113
-      ],
-      "size": [
-        278.3696468820435,
-        58
-      ],
-      "flags": {},
-      "order": 5,
-      "mode": 0,
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "MODEL_PATCH",
-          "type": "MODEL_PATCH",
-          "links": [
-            105
-          ]
-        }
-      ],
-      "properties": {
-        "cnr_id": "comfy-core",
-        "ver": "0.3.76",
-        "Node name for S&R": "ModelPatchLoader"
-      },
-      "widgets_values": [
-        "Z-Image\\Z-Image-Turbo-Fun-Controlnet-Union.safetensors"
-      ],
-      "color": "#232",
-      "bgcolor": "#353"
-    },
-    {
       "id": 60,
       "type": "VAEEncode",
       "pos": [
@@ -519,68 +461,6 @@
         "Node name for S&R": "VAEEncode"
       },
       "widgets_values": []
-    },
-    {
-      "id": 57,
-      "type": "QwenImageDiffsynthControlnet",
-      "pos": [
-        956.9732892203385,
-        186.48952413912906
-      ],
-      "size": [
-        278.97390399018593,
-        138
-      ],
-      "flags": {},
-      "order": 11,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "model",
-          "type": "MODEL",
-          "link": 102
-        },
-        {
-          "name": "model_patch",
-          "type": "MODEL_PATCH",
-          "link": 105
-        },
-        {
-          "name": "vae",
-          "type": "VAE",
-          "link": 104
-        },
-        {
-          "name": "image",
-          "type": "IMAGE",
-          "link": 117
-        },
-        {
-          "name": "mask",
-          "shape": 7,
-          "type": "MASK",
-          "link": null
-        }
-      ],
-      "outputs": [
-        {
-          "name": "MODEL",
-          "type": "MODEL",
-          "links": [
-            119
-          ]
-        }
-      ],
-      "properties": {
-        "cnr_id": "comfy-core",
-        "ver": "0.3.76",
-        "Node name for S&R": "QwenImageDiffsynthControlnet"
-      },
-      "widgets_values": [
-        1
-      ],
-      "color": "#232",
-      "bgcolor": "#353"
     },
     {
       "id": 64,
@@ -641,6 +521,126 @@
         "simple",
         1
       ]
+    },
+    {
+      "id": 55,
+      "type": "MarkdownNote",
+      "pos": [
+        -60.09132385253906,
+        -2.4022865295410156
+      ],
+      "size": [
+        349.13103718118725,
+        214.5148968572393
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "## models\n- [z_image_turbo_bf16.safetensors](https://huggingface.co/Comfy-Org/z_image_turbo/blob/main/split_files/diffusion_models/z_image_turbo_bf16.safetensors)\n- [qwen_3_4b.safetensors](https://huggingface.co/Comfy-Org/z_image_turbo/blob/main/split_files/text_encoders/qwen_3_4b.safetensors)\n- [ae.safetensors](https://huggingface.co/Comfy-Org/z_image_turbo/blob/main/split_files/vae/ae.safetensors)\n\n```\n📂ComfyUI/\n└── 📂models/\n      ├── 📂diffusion_models/\n      │   └── z_image_turbo_bf16.safetensors\n      ├── 📂text_encoders/\n      │   └── qwen_3_4b.safetensors\n      └── 📂vae/\n           └── ae.safetensors\n```"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 58,
+      "type": "ModelPatchLoader",
+      "pos": [
+        622.8999606619018,
+        482.9956856718113
+      ],
+      "size": [
+        278.3696468820435,
+        58
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL_PATCH",
+          "type": "MODEL_PATCH",
+          "links": [
+            105
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.76",
+        "Node name for S&R": "ModelPatchLoader"
+      },
+      "widgets_values": [
+        "Z-Image\\Z-Image-Turbo-Fun-Controlnet-Union-2.1.safetensors"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 57,
+      "type": "QwenImageDiffsynthControlnet",
+      "pos": [
+        956.9732892203385,
+        186.48952413912906
+      ],
+      "size": [
+        278.97390399018593,
+        138
+      ],
+      "flags": {},
+      "order": 11,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 102
+        },
+        {
+          "name": "model_patch",
+          "type": "MODEL_PATCH",
+          "link": 105
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 104
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 117
+        },
+        {
+          "name": "mask",
+          "shape": 7,
+          "type": "MASK",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            119
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.76",
+        "Node name for S&R": "QwenImageDiffsynthControlnet"
+      },
+      "widgets_values": [
+        0.8
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
     }
   ],
   "links": [
@@ -795,11 +795,11 @@
     "ds": {
       "scale": 0.620921323059155,
       "offset": [
-        160.09132385253906,
-        102.40228652954102
+        285.59950041385156,
+        301.28155215925165
       ]
     },
-    "frontendVersion": "1.35.0",
+    "frontendVersion": "1.36.7",
     "VHS_latentpreview": false,
     "VHS_latentpreviewrate": 0,
     "VHS_MetadataImage": true,


### PR DESCRIPTION
- Refresh model patch filename + workflow image

- Replace workflow JSON with 2.1 version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Z-Image-Turbo workflow documentation (English and Japanese) to reference ControlNet Union version 2.1 with new download links.

* **Workflow Updates**
  * Restructured Z-Image-Turbo workflow with improved organization and component handling. Updated frontend version to 1.36.7.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->