### PR TITLE
[codex] Add date metadata to AI capability docs

### DIFF
--- a/src/content/en/ai-capabilities/3d-model-generation.md
+++ b/src/content/en/ai-capabilities/3d-model-generation.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: 3d-model-generation
 navId: 3d-model-generation
 title: 3D Model Generation
+created: 2025-12-03
+updated: 2026-03-02
 summary: "From multi-view to world models"
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/en/ai-capabilities/cfg.md
+++ b/src/content/en/ai-capabilities/cfg.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: cfg
 navId: cfg
 title: CFG
+created: 2025-12-01
+updated: 2026-03-02
 summary: A mechanism that determines the 'effectiveness' of the prompt.
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/en/ai-capabilities/collage-refine.md
+++ b/src/content/en/ai-capabilities/collage-refine.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: collage-refine
 navId: collage-refine
 title: Refining Rough Collages
+created: 2025-12-01
+updated: 2026-03-02
 summary: A technique to finish rough collage images into natural single pictures using
   instruction-based image editing.
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/

--- a/src/content/en/ai-capabilities/conditioning.md
+++ b/src/content/en/ai-capabilities/conditioning.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: conditioning
 navId: conditioning
 title: Conditioning
+created: 2025-11-13
+updated: 2026-03-02
 summary: A mechanism to tell the diffusion model 'what kind of image I want'.
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/en/ai-capabilities/controlnet.md
+++ b/src/content/en/ai-capabilities/controlnet.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: controlnet
 navId: controlnet
 title: ControlNet Techniques
+created: 2025-12-01
+updated: 2026-03-02
 summary: Techniques to control image generation with additional information such as
   poses and line art.
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/

--- a/src/content/en/ai-capabilities/depth-normal-map.md
+++ b/src/content/en/ai-capabilities/depth-normal-map.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: depth-normal-map
 navId: depth-normal-map
 title: "Depth Estimation & Normal Map"
+created: 2025-12-01
+updated: 2026-03-02
 summary: "Technology to extract depth and three-dimensionality from images"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/en/ai-capabilities/diffusion-models.md
+++ b/src/content/en/ai-capabilities/diffusion-models.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: diffusion-models
 navId: diffusion-models
 title: Diffusion Models
+created: 2025-12-01
+updated: 2026-03-02
 summary: The mechanism of diffusion models.
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/en/ai-capabilities/frame-interpolation.md
+++ b/src/content/en/ai-capabilities/frame-interpolation.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: frame-interpolation
 navId: frame-interpolation
 title: Frame Interpolation
+created: 2025-12-01
+updated: 2026-03-02
 summary: Technology to smooth videos or connect distant frames
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/en/ai-capabilities/human-motion-transfer.md
+++ b/src/content/en/ai-capabilities/human-motion-transfer.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: human-motion-transfer
 navId: human-motion-transfer
 title: "Human Motion Transfer"
+created: 2025-12-03
+updated: 2026-03-02
 summary: "Techniques for transferring a source person's movements to a target character or video."
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/en/ai-capabilities/id-transfer.md
+++ b/src/content/en/ai-capabilities/id-transfer.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: id-transfer
 navId: id-transfer
 title: ID Transfer & FaceSwap
+created: 2025-12-01
+updated: 2026-03-02
 summary: Techniques to create images of different scenes while maintaining the person's
   face or identity, and face replacement.
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/

--- a/src/content/en/ai-capabilities/instruction-based-image-editing.md
+++ b/src/content/en/ai-capabilities/instruction-based-image-editing.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: instruction-based-image-editing
 navId: instruction-based-image-editing
 title: Instruction-Based Image Editing
+created: 2025-12-01
+updated: 2026-03-02
 summary: A group of models that perform various image editing tasks simply by following
   text instructions.
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/

--- a/src/content/en/ai-capabilities/latent-diffusion-vae.md
+++ b/src/content/en/ai-capabilities/latent-diffusion-vae.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: latent-diffusion-vae
 navId: latent-diffusion-vae
 title: Latent Diffusion Model & VAE
+created: 2025-12-01
+updated: 2026-03-02
 summary: The role of latent space and VAE.
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/en/ai-capabilities/line-art-coloring.md
+++ b/src/content/en/ai-capabilities/line-art-coloring.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: line-art-coloring
 navId: line-art-coloring
 title: Line Art Coloring
+created: 2025-12-01
+updated: 2026-03-02
 summary: Technology to color line art.
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/en/ai-capabilities/lip-sync.md
+++ b/src/content/en/ai-capabilities/lip-sync.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: lip-sync
 navId: lip-sync
 title: Lip Sync
+created: 2025-12-01
+updated: 2026-03-02
 summary: Technology to move mouth and facial expressions in sync with audio
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/en/ai-capabilities/matting.md
+++ b/src/content/en/ai-capabilities/matting.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: matting
 navId: matting
 title: Matting
+created: 2025-12-03
+updated: 2026-03-02
 summary: "Technology to cut out the foreground from a natural image and separate it from the background"
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/en/ai-capabilities/music-generation.md
+++ b/src/content/en/ai-capabilities/music-generation.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: music-generation
 navId: music-generation
 title: Music Generation
+created: 2025-12-01
+updated: 2026-03-02
 summary: Music Generation overview (draft)
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/en/ai-capabilities/object-detection.md
+++ b/src/content/en/ai-capabilities/object-detection.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: object-detection
 navId: object-detection
 title: Object Detection
+created: 2025-12-01
+updated: 2026-03-02
 summary: "Technology to find 'what' is 'where' in an image"
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/en/ai-capabilities/object-removal.md
+++ b/src/content/en/ai-capabilities/object-removal.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: object-removal
 navId: object-removal
 title: Object Removal
+created: 2025-12-01
+updated: 2026-03-02
 summary: The task of removing specific things from an image and typical methods for
   doing so.
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/

--- a/src/content/en/ai-capabilities/prompt-generation.md
+++ b/src/content/en/ai-capabilities/prompt-generation.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: prompt-generation
 navId: prompt-generation
 title: Prompt Generation & Editing
+created: 2025-12-01
+updated: 2026-03-02
 summary: "Techniques to refine roughly written instructions into prompts that models can easily understand"
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/en/ai-capabilities/region-limited-generation.md
+++ b/src/content/en/ai-capabilities/region-limited-generation.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: region-limited-generation
 navId: region-limited-generation
 title: Region-Limited Generation
+created: 2025-12-01
+updated: 2026-03-02
 summary: Techniques to generate only parts of an image with different conditions,
   and their limitations.
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/

--- a/src/content/en/ai-capabilities/relight.md
+++ b/src/content/en/ai-capabilities/relight.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: relight
 navId: relight
 title: Relight
+created: 2025-12-01
+updated: 2026-03-02
 summary: "Task to adjust lighting of an image by changing light source or ambient light"
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/en/ai-capabilities/sampling.md
+++ b/src/content/en/ai-capabilities/sampling.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: sampling
 navId: sampling
 title: Sampling
+created: 2025-12-01
+updated: 2026-03-27
 summary: Mechanism to decide the procedure for reducing noise
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/en/ai-capabilities/segmentation.md
+++ b/src/content/en/ai-capabilities/segmentation.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: segmentation
 navId: segmentation
 title: "Segmentation"
+created: 2025-12-01
+updated: 2026-03-02
 summary: "Technology to divide images to create masks (mainly SAM family)"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/en/ai-capabilities/style-transfer.md
+++ b/src/content/en/ai-capabilities/style-transfer.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: style-transfer
 navId: style-transfer
 title: Style Transfer
+created: 2025-12-01
+updated: 2026-03-02
 summary: The task of trying to transfer 'style' from a reference image, and its ambiguity.
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/en/ai-capabilities/subject-transfer.md
+++ b/src/content/en/ai-capabilities/subject-transfer.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: subject-transfer
 navId: subject-transfer
 title: Subject Transfer
+created: 2025-12-01
+updated: 2026-03-02
 summary: Technology to make the same thing in a reference image appear in another
   scene.
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/

--- a/src/content/en/ai-capabilities/tag-caption-generation.md
+++ b/src/content/en/ai-capabilities/tag-caption-generation.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: tag-caption-generation
 navId: tag-caption-generation
 title: Tag & Caption Generation
+created: 2025-12-03
+updated: 2026-03-02
 summary: "Technology to automatically add tags and descriptions (captions) from images."
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/en/ai-capabilities/talking-head.md
+++ b/src/content/en/ai-capabilities/talking-head.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: talking-head
 navId: talking-head
 title: talking head
+created: 2025-12-01
+updated: 2026-03-02
 summary: Technology to make a single image or face photo speak in sync with a reference video or audio
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/en/ai-capabilities/tts.md
+++ b/src/content/en/ai-capabilities/tts.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: tts
 navId: tts
 title: TTS
+created: 2025-12-01
+updated: 2026-03-02
 summary: TTS overview (draft)
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/en/ai-capabilities/upscale-restoration.md
+++ b/src/content/en/ai-capabilities/upscale-restoration.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: upscale-restoration
 navId: upscale-restoration
 title: Upscale & Restoration
+created: 2025-11-13
+updated: 2026-03-02
 summary: Technologies to enlarge images or restore degraded ones.
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/en/ai-capabilities/video-generation.md
+++ b/src/content/en/ai-capabilities/video-generation.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: video-generation
 navId: video-generation
 title: Video Generation
+created: 2025-12-01
+updated: 2026-03-02
 summary: Video Generation overview (draft)
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/en/ai-capabilities/video-to-audio.md
+++ b/src/content/en/ai-capabilities/video-to-audio.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: video-to-audio
 navId: video-to-audio
 title: video2audio
+created: 2025-12-01
+updated: 2026-03-02
 summary: Technology to automatically generate sound effects and environmental sounds from video
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/en/ai-capabilities/video-upscale-restoration.md
+++ b/src/content/en/ai-capabilities/video-upscale-restoration.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: video-upscale-restoration
 navId: video-upscale-restoration
 title: Video Upscale & Restoration
+created: 2025-12-01
+updated: 2026-03-02
 summary: Dedicated models to make videos larger and cleaner
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/en/ai-capabilities/virtual-try-on.md
+++ b/src/content/en/ai-capabilities/virtual-try-on.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: virtual-try-on
 navId: virtual-try-on
 title: Virtual Try-On
+created: 2025-12-01
+updated: 2026-03-02
 summary: The task of replacing only the clothes with a different design or variation.
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/en/ai-capabilities/voice-clone.md
+++ b/src/content/en/ai-capabilities/voice-clone.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: voice-clone
 navId: voice-clone
 title: Voice Clone
+created: 2025-12-01
+updated: 2026-03-02
 summary: Voice Clone overview (draft)
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/3d-model-generation.md
+++ b/src/content/ja/ai-capabilities/3d-model-generation.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: 3d-model-generation
 navId: 3d-model-generation
 title: 3Dモデル生成
+created: 2025-12-03
+updated: 2026-03-02
 summary: "3マルチビューからワールドモデルまで"
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/cfg.md
+++ b/src/content/ja/ai-capabilities/cfg.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: cfg
 navId: cfg
 title: CFG
+created: 2025-11-29
+updated: 2026-03-02
 summary: プロンプトの「効き具合」を決める仕組み
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/collage-refine.md
+++ b/src/content/ja/ai-capabilities/collage-refine.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: collage-refine
 navId: collage-refine
 title: 雑コラのリファイン
+created: 2025-12-01
+updated: 2026-03-02
 summary: 雑なコラージュ画像を、指示ベース画像編集で自然な一枚絵に仕上げるテクニック
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/conditioning.md
+++ b/src/content/ja/ai-capabilities/conditioning.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: conditioning
 navId: conditioning
 title: Conditioning
+created: 2025-11-13
+updated: 2026-03-02
 summary: 拡散モデルに「こういう画像がほしい」と伝える仕組み
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/controlnet.md
+++ b/src/content/ja/ai-capabilities/controlnet.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: controlnet
 navId: controlnet
 title: ControlNet系
+created: 2025-12-01
+updated: 2026-03-02
 summary: ポーズや線画などの追加情報で画像生成をコントロールする技術
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/depth-normal-map.md
+++ b/src/content/ja/ai-capabilities/depth-normal-map.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: depth-normal-map
 navId: depth-normal-map
 title: "深度推定とノーマルマップ生成"
+created: 2025-12-01
+updated: 2026-03-02
 summary: "画像から奥行きや立体感を取り出す技術"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/ja/ai-capabilities/diffusion-models.md
+++ b/src/content/ja/ai-capabilities/diffusion-models.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: diffusion-models
 navId: diffusion-models
 title: 拡散モデル
+created: 2025-11-29
+updated: 2026-03-02
 summary: 拡散モデルの仕組み
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/frame-interpolation.md
+++ b/src/content/ja/ai-capabilities/frame-interpolation.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: frame-interpolation
 navId: frame-interpolation
 title: フレーム補間
+created: 2025-12-01
+updated: 2026-03-02
 summary: 動画をなめらかにしたり、離れたフレーム同士をつなぐ技術
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/human-motion-transfer.md
+++ b/src/content/ja/ai-capabilities/human-motion-transfer.md
@@ -6,11 +6,13 @@ section: ai-capabilities
 slug: human-motion-transfer
 navId: human-motion-transfer
 title: Human Motion Transfer
+created: 2025-12-03
+updated: 2026-03-02
 summary: 別の動画の動きをキャラクターに移す技術
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:
 image:
-------
+---
 
 ## Human Motion Transferとは？
 

--- a/src/content/ja/ai-capabilities/id-transfer.md
+++ b/src/content/ja/ai-capabilities/id-transfer.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: id-transfer
 navId: id-transfer
 title: ID転送とFaceSwap
+created: 2025-12-01
+updated: 2026-03-02
 summary: 人物の顔や本人性を保ったまま、別シーンの画像を作る技術と顔差し替え
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/instruction-based-image-editing.md
+++ b/src/content/ja/ai-capabilities/instruction-based-image-editing.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: instruction-based-image-editing
 navId: instruction-based-image-editing
 title: 指示ベース画像編集
+created: 2025-12-01
+updated: 2026-03-02
 summary: テキストで指示するだけで、さまざまな画像編集タスクをこなすモデル群
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/latent-diffusion-vae.md
+++ b/src/content/ja/ai-capabilities/latent-diffusion-vae.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: latent-diffusion-vae
 navId: latent-diffusion-vae
 title: Latent Diffusion ModelとVAE
+created: 2025-11-29
+updated: 2026-03-02
 summary: 潜在空間とVAEの役割
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/line-art-coloring.md
+++ b/src/content/ja/ai-capabilities/line-art-coloring.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: line-art-coloring
 navId: line-art-coloring
 title: 線画着色
+created: 2025-12-01
+updated: 2026-03-02
 summary: 線画に色を塗る技術
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/lip-sync.md
+++ b/src/content/ja/ai-capabilities/lip-sync.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: lip-sync
 navId: lip-sync
 title: リップシンク
+created: 2025-12-01
+updated: 2026-03-02
 summary: 音声に合わせて口や表情を動かす技術
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/matting.md
+++ b/src/content/ja/ai-capabilities/matting.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: matting
 navId: matting
 title: マッティング
+created: 2025-12-03
+updated: 2026-03-02
 summary: "自然な画像から前景を切り出し、背景と分離する技術"
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/music-generation.md
+++ b/src/content/ja/ai-capabilities/music-generation.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: music-generation
 navId: music-generation
 title: 音楽生成
+created: 2025-12-01
+updated: 2026-03-02
 summary: 音楽生成 の概要ページ（準備中）
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/object-detection.md
+++ b/src/content/ja/ai-capabilities/object-detection.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: object-detection
 navId: object-detection
 title: 物体検出
+created: 2025-12-01
+updated: 2026-03-02
 summary: "画像の中に「何が」「どこに」あるかを見つける技術"
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/object-removal.md
+++ b/src/content/ja/ai-capabilities/object-removal.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: object-removal
 navId: object-removal
 title: オブジェクト除去
+created: 2025-12-01
+updated: 2026-03-02
 summary: 画像から特定のものだけを消すタスクと、その代表的なやり方
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/prompt-generation.md
+++ b/src/content/ja/ai-capabilities/prompt-generation.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: prompt-generation
 navId: prompt-generation
 title: プロンプト生成・編集
+created: 2025-12-01
+updated: 2026-03-02
 summary: "ざっくり書いた指示を、モデルが理解しやすいプロンプトに整えるテクニック"
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/region-limited-generation.md
+++ b/src/content/ja/ai-capabilities/region-limited-generation.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: region-limited-generation
 navId: region-limited-generation
 title: 領域指定生成
+created: 2025-12-01
+updated: 2026-03-02
 summary: 画像の一部だけを別の条件で生成しようとする技術と、その限界
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/relight.md
+++ b/src/content/ja/ai-capabilities/relight.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: relight
 navId: relight
 title: リライト
+created: 2025-12-03
+updated: 2026-03-02
 summary: "光源や環境光を変えて、画像のライティングを調整するタスク"
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/sampling.md
+++ b/src/content/ja/ai-capabilities/sampling.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: sampling
 navId: sampling
 title: Sampling
+created: 2025-11-29
+updated: 2026-03-27
 summary: ノイズをどのような手順で減らしていくかを決める仕組み
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/segmentation.md
+++ b/src/content/ja/ai-capabilities/segmentation.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: segmentation
 navId: segmentation
 title: "セグメンテーション"
+created: 2025-12-01
+updated: 2026-03-02
 summary: "マスクをつくるために画像を分ける技術（主にSAM系）"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/ja/ai-capabilities/style-transfer.md
+++ b/src/content/ja/ai-capabilities/style-transfer.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: style-transfer
 navId: style-transfer
 title: スタイル転送
+created: 2025-12-01
+updated: 2026-03-02
 summary: 「スタイル」を参照画像から移そうとするタスクと、その曖昧さ
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/subject-transfer.md
+++ b/src/content/ja/ai-capabilities/subject-transfer.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: subject-transfer
 navId: subject-transfer
 title: Subject転送
+created: 2025-12-01
+updated: 2026-03-02
 summary: 参照画像と同じものを別のシーンに登場させる技術
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/tag-caption-generation.md
+++ b/src/content/ja/ai-capabilities/tag-caption-generation.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: tag-caption-generation
 navId: tag-caption-generation
 title: タグ・キャプション生成
+created: 2025-12-03
+updated: 2026-03-02
 summary: "画像からタグや説明文（キャプション）を自動で付ける技術"
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/talking-head.md
+++ b/src/content/ja/ai-capabilities/talking-head.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: talking-head
 navId: talking-head
 title: talking head
+created: 2025-12-01
+updated: 2026-03-02
 summary: 1枚絵や顔写真を、参照動画や音声に合わせてしゃべらせる技術
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/tts.md
+++ b/src/content/ja/ai-capabilities/tts.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: tts
 navId: tts
 title: TTS
+created: 2025-12-01
+updated: 2026-03-02
 summary: TTS の概要ページ（準備中）
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/upscale-restoration.md
+++ b/src/content/ja/ai-capabilities/upscale-restoration.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: upscale-restoration
 navId: upscale-restoration
 title: アップスケール・画像修復
+created: 2025-11-13
+updated: 2026-03-02
 summary: 画像を大きくしたり、劣化した画像を修復したりする技術
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/video-generation.md
+++ b/src/content/ja/ai-capabilities/video-generation.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: video-generation
 navId: video-generation
 title: 動画生成
+created: 2025-12-01
+updated: 2026-03-02
 summary: 動画生成 の概要ページ（準備中）
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/video-to-audio.md
+++ b/src/content/ja/ai-capabilities/video-to-audio.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: video-to-audio
 navId: video-to-audio
 title: video2audio
+created: 2025-12-01
+updated: 2026-03-02
 summary: 動画から効果音や環境音を自動生成する技術
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/video-upscale-restoration.md
+++ b/src/content/ja/ai-capabilities/video-upscale-restoration.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: video-upscale-restoration
 navId: video-upscale-restoration
 title: アップスケール・動画修復
+created: 2025-12-01
+updated: 2026-03-02
 summary: 動画を大きく・きれいにするための専用モデル
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/virtual-try-on.md
+++ b/src/content/ja/ai-capabilities/virtual-try-on.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: virtual-try-on
 navId: virtual-try-on
 title: 着せ替え
+created: 2025-12-01
+updated: 2026-03-02
 summary: 服だけを別のデザイン・バリエーションに差し替えるタスク
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/ai-capabilities/voice-clone.md
+++ b/src/content/ja/ai-capabilities/voice-clone.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: voice-clone
 navId: voice-clone
 title: ボイスクローン
+created: 2025-12-01
+updated: 2026-03-02
 summary: ボイスクローン の概要ページ（準備中）
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/3d-model-generation.md
+++ b/src/content/zh/ai-capabilities/3d-model-generation.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: 3d-model-generation
 navId: 3d-model-generation
 title: 3D 模型生成
+created: 2026-02-06
+updated: 2026-03-02
 summary: "从多视角到世界模型"
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/cfg.md
+++ b/src/content/zh/ai-capabilities/cfg.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: cfg
 navId: cfg
 title: CFG
+created: 2026-02-06
+updated: 2026-03-02
 summary: 决定提示词“生效程度”的机制
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/collage-refine.md
+++ b/src/content/zh/ai-capabilities/collage-refine.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: collage-refine
 navId: collage-refine
 title: 杂乱拼贴的优化
+created: 2026-02-06
+updated: 2026-03-02
 summary: 将杂乱的拼贴图像，通过基于指令的图像编辑整理成自然的一张画的技巧
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/conditioning.md
+++ b/src/content/zh/ai-capabilities/conditioning.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: conditioning
 navId: conditioning
 title: Conditioning (调节/条件)
+created: 2026-02-06
+updated: 2026-03-02
 summary: 告诉扩散模型“想要这样的图像”的机制
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/controlnet.md
+++ b/src/content/zh/ai-capabilities/controlnet.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: controlnet
 navId: controlnet
 title: ControlNet 系
+created: 2026-02-06
+updated: 2026-03-02
 summary: 使用姿势或线稿等附加信息控制图像生成的技术
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/depth-normal-map.md
+++ b/src/content/zh/ai-capabilities/depth-normal-map.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: depth-normal-map
 navId: depth-normal-map
 title: "深度推断与法线贴图生成"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "从图像中提取进深感或立体感的技术"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/ai-capabilities/diffusion-models.md
+++ b/src/content/zh/ai-capabilities/diffusion-models.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: diffusion-models
 navId: diffusion-models
 title: 扩散模型
+created: 2026-02-06
+updated: 2026-03-02
 summary: 扩散模型的机制
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/frame-interpolation.md
+++ b/src/content/zh/ai-capabilities/frame-interpolation.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: frame-interpolation
 navId: frame-interpolation
 title: 帧插值
+created: 2026-02-06
+updated: 2026-03-02
 summary: 让视频更流畅，或连接分离帧的技术
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/human-motion-transfer.md
+++ b/src/content/zh/ai-capabilities/human-motion-transfer.md
@@ -6,6 +6,8 @@ section: ai-capabilities
 slug: human-motion-transfer
 navId: human-motion-transfer
 title: Human Motion Transfer
+created: 2026-02-06
+updated: 2026-03-02
 summary: 将其他视频的动作转移给角色的技术
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/id-transfer.md
+++ b/src/content/zh/ai-capabilities/id-transfer.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: id-transfer
 navId: id-transfer
 title: ID 转移与 FaceSwap
+created: 2026-02-06
+updated: 2026-03-02
 summary: 保持人物面部或本人特征，创作不同场景图像的技术与换脸
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/instruction-based-image-editing.md
+++ b/src/content/zh/ai-capabilities/instruction-based-image-editing.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: instruction-based-image-editing
 navId: instruction-based-image-editing
 title: 基于指令的图像编辑
+created: 2026-02-06
+updated: 2026-03-02
 summary: 只需用文本指示，就能完成各种图像编辑任务的模型群
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/latent-diffusion-vae.md
+++ b/src/content/zh/ai-capabilities/latent-diffusion-vae.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: latent-diffusion-vae
 navId: latent-diffusion-vae
 title: Latent Diffusion Model (潜扩散模型) 与 VAE
+created: 2026-02-06
+updated: 2026-03-02
 summary: 潜在空间和 VAE 的作用
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/line-art-coloring.md
+++ b/src/content/zh/ai-capabilities/line-art-coloring.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: line-art-coloring
 navId: line-art-coloring
 title: 线稿上色
+created: 2026-02-06
+updated: 2026-03-02
 summary: 给线稿上色的技术
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/lip-sync.md
+++ b/src/content/zh/ai-capabilities/lip-sync.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: lip-sync
 navId: lip-sync
 title: Lip Sync
+created: 2026-02-06
+updated: 2026-03-02
 summary: 配合音频移动嘴巴或表情的技术
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/matting.md
+++ b/src/content/zh/ai-capabilities/matting.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: matting
 navId: matting
 title: 抠图
+created: 2026-02-06
+updated: 2026-03-02
 summary: "从自然图像中抠出前景，与背景分离的技术"
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/music-generation.md
+++ b/src/content/zh/ai-capabilities/music-generation.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: music-generation
 navId: music-generation
 title: 音乐生成
+created: 2025-12-01
+updated: 2026-03-02
 summary: 音乐生成 的概要页面（准备中）
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/object-detection.md
+++ b/src/content/zh/ai-capabilities/object-detection.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: object-detection
 navId: object-detection
 title: 物体检测
+created: 2026-02-06
+updated: 2026-03-02
 summary: "找出图像中即“有什么”“在哪里”的技术"
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/object-removal.md
+++ b/src/content/zh/ai-capabilities/object-removal.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: object-removal
 navId: object-removal
 title: 对象去除
+created: 2026-02-06
+updated: 2026-03-02
 summary: 从图像中仅去除特定物品的任务，及其代表性的方法
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/prompt-generation.md
+++ b/src/content/zh/ai-capabilities/prompt-generation.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: prompt-generation
 navId: prompt-generation
 title: 提示词生成・编辑
+created: 2026-02-06
+updated: 2026-03-02
 summary: 将粗略的指示整理成模型容易理解的提示词的技术
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/region-limited-generation.md
+++ b/src/content/zh/ai-capabilities/region-limited-generation.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: region-limited-generation
 navId: region-limited-generation
 title: 区域指定生成
+created: 2026-02-06
+updated: 2026-03-02
 summary: 试图只按照该条件生成图像一部分的技术，及其局限性
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/relight.md
+++ b/src/content/zh/ai-capabilities/relight.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: relight
 navId: relight
 title: 重打光
+created: 2026-02-06
+updated: 2026-03-02
 summary: "改变光源或环境光，调整图像的打光的任务"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/ai-capabilities/sampling.md
+++ b/src/content/zh/ai-capabilities/sampling.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: sampling
 navId: sampling
 title: 采样 (Sampling)
+created: 2026-02-06
+updated: 2026-03-27
 summary: 决定以何种步骤减少噪点的机制
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/segmentation.md
+++ b/src/content/zh/ai-capabilities/segmentation.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: segmentation
 navId: segmentation
 title: "分割"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "为了制作蒙版而区分图像的技术（主要是 SAM 系）"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/ai-capabilities/style-transfer.md
+++ b/src/content/zh/ai-capabilities/style-transfer.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: style-transfer
 navId: style-transfer
 title: 风格转移
+created: 2026-02-06
+updated: 2026-03-02
 summary: 试图从参考图像中转移“风格”的任务，及其模糊性
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/subject-transfer.md
+++ b/src/content/zh/ai-capabilities/subject-transfer.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: subject-transfer
 navId: subject-transfer
 title: Subject 转移
+created: 2026-02-06
+updated: 2026-03-02
 summary: 让参考图像中的相同物体在不同场景中登场的技术
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/tag-caption-generation.md
+++ b/src/content/zh/ai-capabilities/tag-caption-generation.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: tag-caption-generation
 navId: tag-caption-generation
 title: 标签・描述生成
+created: 2026-02-06
+updated: 2026-03-02
 summary: "从图像自动添加标签或说明文（Caption）的技术"
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/talking-head.md
+++ b/src/content/zh/ai-capabilities/talking-head.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: talking-head
 navId: talking-head
 title: Talking Head
+created: 2026-02-06
+updated: 2026-03-02
 summary: 让单张图片或人脸照片配合参考视频或音频说话的技术
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/tts.md
+++ b/src/content/zh/ai-capabilities/tts.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: tts
 navId: tts
 title: TTS
+created: 2025-12-01
+updated: 2026-03-02
 summary: TTS 的概要页面（准备中）
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/upscale-restoration.md
+++ b/src/content/zh/ai-capabilities/upscale-restoration.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: upscale-restoration
 navId: upscale-restoration
 title: 放大・图像修复
+created: 2026-02-06
+updated: 2026-03-02
 summary: 放大图像，或修复劣化图像的技术
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/video-generation.md
+++ b/src/content/zh/ai-capabilities/video-generation.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: video-generation
 navId: video-generation
 title: 视频生成
+created: 2025-12-01
+updated: 2026-03-02
 summary: 视频生成 的概要页面（准备中）
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/video-to-audio.md
+++ b/src/content/zh/ai-capabilities/video-to-audio.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: video-to-audio
 navId: video-to-audio
 title: video2audio
+created: 2026-02-06
+updated: 2026-03-02
 summary: 从视频自动生成音效或环境音的技术
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/video-upscale-restoration.md
+++ b/src/content/zh/ai-capabilities/video-upscale-restoration.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: video-upscale-restoration
 navId: video-upscale-restoration
 title: 放大・视频修复
+created: 2026-02-06
+updated: 2026-03-02
 summary: 让视频变大・变清晰的专用模型
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/virtual-try-on.md
+++ b/src/content/zh/ai-capabilities/virtual-try-on.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: virtual-try-on
 navId: virtual-try-on
 title: 换装
+created: 2026-02-06
+updated: 2026-03-02
 summary: 只将衣服替换为不同设计・变体的任务
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/zh/ai-capabilities/voice-clone.md
+++ b/src/content/zh/ai-capabilities/voice-clone.md
@@ -5,6 +5,8 @@ section: ai-capabilities
 slug: voice-clone
 navId: voice-clone
 title: 声音克隆
+created: 2026-02-06
+updated: 2026-03-02
 summary: 声音克隆 的概要页面（准备中）
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:


### PR DESCRIPTION
## Summary

- add `created` / `updated` metadata to AI Capabilities pages across `ja`, `en`, and `zh`
- normalize one malformed frontmatter delimiter in the Japanese Human Motion Transfer page while adding the dates

## Notes

This is a metadata-only follow-up split from the larger date metadata backup branch so the PR stays under the CodeRabbit file limit.

## Validation

- `npm run build`
