### PR TITLE
[codex] Add date metadata to basic workflow docs

### DIFF
--- a/src/content/en/basic-workflows/ace-plus-plus.md
+++ b/src/content/en/basic-workflows/ace-plus-plus.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: ace-plus-plus
 navId: ace-plus-plus
 title: "ACE++"
+created: 2025-12-10
+updated: 2026-03-02
 summary: "Extending Flux.1 Fill with ACE++"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/api-nodes.md
+++ b/src/content/en/basic-workflows/api-nodes.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: api-nodes
 navId: api-nodes
 title: "API Nodes"
+created: 2025-12-11
+updated: 2026-03-02
 summary: "How to use external closed models with API nodes in ComfyUI"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/auraflow.md
+++ b/src/content/en/basic-workflows/auraflow.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: auraflow
 navId: auraflow
 title: "AuraFlow"
+created: 2025-12-09
+updated: 2026-03-02
 summary: "AuraFlow and Pony V7 rough organization"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/chroma1-hd.md
+++ b/src/content/en/basic-workflows/chroma1-hd.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: chroma1-hd
 navId: chroma1-hd
 title: "Chroma1-HD"
+created: 2025-12-11
+updated: 2026-03-02
 summary: "Extending Flux.1-schnell with Chroma1-HD"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/controlnet-prep.md
+++ b/src/content/en/basic-workflows/controlnet-prep.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: controlnet-prep
 navId: controlnet-prep
 title: "ControlNet Preprocessor"
+created: 2025-12-08
+updated: 2026-03-02
 summary: "Creating auxiliary images for use with ControlNet"
 tags: ["controlnet"]
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"

--- a/src/content/en/basic-workflows/detailer.md
+++ b/src/content/en/basic-workflows/detailer.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: detailer
 navId: detailer
 title: "Detailer"
+created: 2025-12-09
+updated: 2026-03-02
 summary: "A mechanism to cut out only small faces or details and inpaint them"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/differential-diffusion.md
+++ b/src/content/en/basic-workflows/differential-diffusion.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: differential-diffusion
 navId: differential-diffusion
 title: "Differential Diffusion"
+created: 2025-12-07
+updated: 2026-03-02
 summary: "Control the amount of change with mask density"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/esrgan.md
+++ b/src/content/en/basic-workflows/esrgan.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: esrgan
 navId: esrgan
 title: "ESRGAN"
+created: 2025-12-09
+updated: 2026-03-02
 summary: "Image upscaling and face restoration"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/external-llm-server.md
+++ b/src/content/en/basic-workflows/external-llm-server.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: external-llm-server
 navId: external-llm-server
 title: "External LLM Server Integration"
+created: 2026-02-18
+updated: 2026-03-02
 summary: "Run an LLM outside ComfyUI and connect to it"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/florence2.md
+++ b/src/content/en/basic-workflows/florence2.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: florence2
 navId: florence2
 title: "Florence-2"
+created: 2025-12-09
+updated: 2026-03-02
 summary: "Image caption generation and object detection using Florence-2"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/flux-1-kontext.md
+++ b/src/content/en/basic-workflows/flux-1-kontext.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: flux-1-kontext
 navId: flux-1-kontext
 title: "Flux.1 Kontext"
+created: 2025-12-11
+updated: 2026-03-02
 summary: "Instruction-based image editing with Flux.1 Kontext."
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/flux-1-tools.md
+++ b/src/content/en/basic-workflows/flux-1-tools.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: flux-1-tools
 navId: flux-1-tools
 title: "Flux.1 Tools"
+created: 2025-12-10
+updated: 2026-03-02
 summary: "How to use Flux.1 Tools"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/flux-1.md
+++ b/src/content/en/basic-workflows/flux-1.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: flux-1
 navId: flux-1
 title: "Flux.1"
+created: 2025-12-12
+updated: 2026-03-02
 summary: "Basics of Flux.1 and usage in ComfyUI"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/flux-2-klein.md
+++ b/src/content/en/basic-workflows/flux-2-klein.md
@@ -6,6 +6,8 @@ section: basic-workflows
 slug: flux-2-klein
 navId: flux-2-klein
 title: "FLUX.2 [klein]"
+created: 2026-01-22
+updated: 2026-03-02
 summary: "FLUX.2 [klein] generation and image editing workflow"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/joycaption.md
+++ b/src/content/en/basic-workflows/joycaption.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: joycaption
 navId: joycaption
 title: "JoyCaption"
+created: 2025-12-09
+updated: 2026-03-02
 summary: "Image caption generation using JoyCaption"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/ksampler-advanced.md
+++ b/src/content/en/basic-workflows/ksampler-advanced.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: ksampler-advanced
 navId: ksampler-advanced
 title: "KSampler (Advanced) Node"
+created: 2025-12-06
+updated: 2026-03-02
 summary: "Understanding the KSampler (Advanced) Node"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/liveportrait.md
+++ b/src/content/en/basic-workflows/liveportrait.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: liveportrait
 navId: liveportrait
 title: "LivePortrait"
+created: 2025-12-12
+updated: 2026-03-02
 summary: "Controlling expression and head movement from a single face photo with LivePortrait"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/llm-mllm.md
+++ b/src/content/en/basic-workflows/llm-mllm.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: llm-mllm
 navId: llm-mllm
 title: "LLM / MLLM"
+created: 2026-02-18
+updated: 2026-03-27
 summary: "What you can do with LLMs in ComfyUI"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/ltx-2-3.md
+++ b/src/content/en/basic-workflows/ltx-2-3.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: ltx-2-3
 navId: ltx-2-3
 title: "LTX 2.3"
+created: 2026-03-22
+updated: 2026-04-13
 summary: "Handle text2video, image2video, audio2video, and audio-image2video with LTX 2.3"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/ltx-2.md
+++ b/src/content/en/basic-workflows/ltx-2.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: ltx-2
 navId: ltx-2
 title: "LTX-2"
+created: 2026-01-10
+updated: 2026-04-13
 summary: "Handle text2video / image2video / audio2video with LTX-2"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/lumina-image-2.0.md
+++ b/src/content/en/basic-workflows/lumina-image-2.0.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: lumina-image-2.0
 navId: lumina-image-2.0
 title: "Lumina-Image 2.0"
+created: 2025-12-11
+updated: 2026-03-02
 summary: "Basics of Lumina-Image 2.0 and usage in ComfyUI"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/model-merge.md
+++ b/src/content/en/basic-workflows/model-merge.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: model-merge
 navId: model-merge
 title: "Model Merge & Difference LoRA"
+created: 2025-12-11
+updated: 2026-03-02
 summary: "How to merge checkpoints/LoRAs and create difference LoRAs"
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/en/basic-workflows/qwen-image-edit.md
+++ b/src/content/en/basic-workflows/qwen-image-edit.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: qwen-image-edit
 navId: qwen-image-edit
 title: "Qwen-Image-Edit"
+created: 2025-12-11
+updated: 2026-03-02
 summary: "Instruction-based image editing with Qwen-Image-Edit"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/qwen-image-layered.md
+++ b/src/content/en/basic-workflows/qwen-image-layered.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: qwen-image-layered
 navId: qwen-image-layered
 title: "Qwen-Image-Layered"
+created: 2025-12-31
+updated: 2026-03-02
 summary: "Decompose input image into multiple RGBA layers"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/qwen-image.md
+++ b/src/content/en/basic-workflows/qwen-image.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: qwen-image
 navId: qwen-image
 title: "Qwen-Image"
+created: 2025-12-11
+updated: 2026-03-02
 summary: "How to use Qwen-Image"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/reactor.md
+++ b/src/content/en/basic-workflows/reactor.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: reactor
 navId: reactor
 title: "ReActor"
+created: 2025-12-09
+updated: 2026-03-02
 summary: "FaceSwap using ReActor"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/sd15-basics.md
+++ b/src/content/en/basic-workflows/sd15-basics.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-basics
 navId: sd15-basics
 title: "Basics of Image Generation (SD1.5)"
+created: 2025-11-13
+updated: 2026-03-02
 summary: "Basics of Image Generation with Stable Diffusion 1.5"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/sd15-controlnet.md
+++ b/src/content/en/basic-workflows/sd15-controlnet.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-controlnet
 navId: sd15-controlnet
 title: "ControlNet"
+created: 2025-12-08
+updated: 2026-03-02
 summary: "Controlling image generation using poses and line drawings"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 tags: ["controlnet"]

--- a/src/content/en/basic-workflows/sd15-hires-fix.md
+++ b/src/content/en/basic-workflows/sd15-hires-fix.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-hires-fix
 navId: sd15-hires-fix
 title: "Hires.fix"
+created: 2025-12-07
+updated: 2026-03-02
 summary: "High-Resolution Image Generation with Hires.fix"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/sd15-image2image.md
+++ b/src/content/en/basic-workflows/sd15-image2image.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-image2image
 navId: sd15-image2image
 title: "image2image"
+created: 2025-12-06
+updated: 2026-03-02
 summary: "Learning image2image with Stable Diffusion 1.5"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/sd15-inpainting.md
+++ b/src/content/en/basic-workflows/sd15-inpainting.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-inpainting
 navId: sd15-inpainting
 title: "inpainting"
+created: 2025-12-07
+updated: 2026-03-02
 summary: "Editing only a part of an image with inpainting"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/sd15-ip-adapter.md
+++ b/src/content/en/basic-workflows/sd15-ip-adapter.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-ip-adapter
 navId: sd15-ip-adapter
 title: "IP-Adapter"
+created: 2025-12-09
+updated: 2026-03-02
 summary: "The original mechanism for transferring style and subject from a reference image"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/sd15-lora.md
+++ b/src/content/en/basic-workflows/sd15-lora.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-lora
 navId: sd15-lora
 title: "LoRA"
+created: 2025-12-06
+updated: 2026-03-02
 summary: "LoRA in Stable Diffusion 1.5"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/sd15-outpainting.md
+++ b/src/content/en/basic-workflows/sd15-outpainting.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-outpainting
 navId: sd15-outpainting
 title: "outpainting"
+created: 2025-12-07
+updated: 2026-03-02
 summary: "Drawing outside the image with outpainting"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/sd15-text2image.md
+++ b/src/content/en/basic-workflows/sd15-text2image.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-text2image
 navId: sd15-text2image
 title: "text2image"
+created: 2025-12-06
+updated: 2026-03-02
 summary: "text2image with Stable Diffusion 1.5"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/sd15-textual-inversion.md
+++ b/src/content/en/basic-workflows/sd15-textual-inversion.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-textual-inversion
 navId: sd15-textual-inversion
 title: "Textual Inversion"
+created: 2025-12-06
+updated: 2026-03-02
 summary: "Textual Inversion in Stable Diffusion 1.5"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/sdxl-anime.md
+++ b/src/content/en/basic-workflows/sdxl-anime.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sdxl-anime
 navId: sdxl-anime
 title: "Anime-style SDXL Models"
+created: 2025-12-10
+updated: 2026-03-02
 summary: "Rough organization of SDXL-based anime models"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/sdxl.md
+++ b/src/content/en/basic-workflows/sdxl.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sdxl
 navId: sdxl
 title: "SDXL"
+created: 2025-12-10
+updated: 2026-03-02
 summary: "How to use SDXL"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/speed-and-efficiency.md
+++ b/src/content/en/basic-workflows/speed-and-efficiency.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: speed-and-efficiency
 navId: speed-and-efficiency
 title: "Speed and Efficiency"
+created: 2025-12-11
+updated: 2026-03-02
 summary: "Organizing speed-up and lightweighting techniques for diffusion models and using them according to purpose"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/ultimate-sd-upscale.md
+++ b/src/content/en/basic-workflows/ultimate-sd-upscale.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: ultimate-sd-upscale
 navId: ultimate-sd-upscale
 title: "Ultimate SD Upscale"
+created: 2025-12-09
+updated: 2026-03-02
 summary: "Super resolution upscale using Tile and ControlNet"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/wan-2-1-vace.md
+++ b/src/content/en/basic-workflows/wan-2-1-vace.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: wan-2-1-vace
 navId: wan-2-1-vace
 title: "Wan 2.1 VACE"
+created: 2025-12-13
+updated: 2026-03-02
 summary: "Handle ControlNet-like control, in/outpainting, reference2video, and Extension with Wan 2.1 VACE"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/wan-2-1.md
+++ b/src/content/en/basic-workflows/wan-2-1.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: wan-2-1
 navId: wan-2-1
 title: "Wan 2.1"
+created: 2025-12-12
+updated: 2026-03-02
 summary: "Basic workflow for handling text2video, image2video, and FLF2V with Wan2.1"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/wan-2-2.md
+++ b/src/content/en/basic-workflows/wan-2-2.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: wan-2-2
 navId: wan-2-2
 title: "Wan 2.2"
+created: 2025-12-12
+updated: 2026-03-02
 summary: "Video generation using text2video / image2video / FLF2V with Wan 2.2"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/wan-animate.md
+++ b/src/content/en/basic-workflows/wan-animate.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: wan-animate
 navId: wan-animate
 title: "Wan-Animate"
+created: 2025-12-12
+updated: 2026-03-02
 summary: "Perform motion transfer to people/characters with Wan-Animate"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/z-image-turbo.md
+++ b/src/content/en/basic-workflows/z-image-turbo.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: z-image-turbo
 navId: z-image-turbo
 title: "Z-Image-Turbo"
+created: 2025-12-12
+updated: 2026-03-02
 summary: "Image generation with Z-Image-Turbo"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/en/basic-workflows/z-image.md
+++ b/src/content/en/basic-workflows/z-image.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: z-image
 navId: z-image
 title: "Z-Image"
+created: 2026-01-31
+updated: 2026-03-02
 summary: "Image generation with Z-Image"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/ace-plus-plus.md
+++ b/src/content/ja/basic-workflows/ace-plus-plus.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: ace-plus-plus
 navId: ace-plus-plus
 title: "ACE++"
+created: 2025-12-10
+updated: 2026-03-02
 summary: "ACE++でFlux.1 Fillを拡張する"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/api-nodes.md
+++ b/src/content/ja/basic-workflows/api-nodes.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: api-nodes
 navId: api-nodes
 title: "APIノード"
+created: 2025-12-11
+updated: 2026-03-02
 summary: "ComfyUIのAPIノードで外部のクローズドモデルを利用する方法"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/auraflow.md
+++ b/src/content/ja/basic-workflows/auraflow.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: auraflow
 navId: auraflow
 title: "AuraFlow"
+created: 2025-12-09
+updated: 2026-03-02
 summary: "AuraFlow と Pony V7 をざっくり整理"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/chroma1-hd.md
+++ b/src/content/ja/basic-workflows/chroma1-hd.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: chroma1-hd
 navId: chroma1-hd
 title: "Chroma1-HD"
+created: 2025-12-11
+updated: 2026-03-02
 summary: "Chroma1-HDでFlux.1-schnellを拡張する"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/controlnet-prep.md
+++ b/src/content/ja/basic-workflows/controlnet-prep.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: controlnet-prep
 navId: controlnet-prep
 title: "ControlNet Preprocessor"
+created: 2025-12-08
+updated: 2026-03-02
 summary: "ControlNetで使う補助画像を作る"
 tags: ["controlnet"]
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"

--- a/src/content/ja/basic-workflows/detailer.md
+++ b/src/content/ja/basic-workflows/detailer.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: detailer
 navId: detailer
 title: "Detailer"
+created: 2025-12-08
+updated: 2026-03-02
 summary: "小さな顔や細部だけを切り出してinpaintする仕組み"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/differential-diffusion.md
+++ b/src/content/ja/basic-workflows/differential-diffusion.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: differential-diffusion
 navId: differential-diffusion
 title: "Differential Diffusion"
+created: 2025-12-07
+updated: 2026-03-02
 summary: "マスクの濃度で変化量をコントロールする"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/esrgan.md
+++ b/src/content/ja/basic-workflows/esrgan.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: esrgan
 navId: esrgan
 title: "ESRGAN"
+created: 2025-12-08
+updated: 2026-03-02
 summary: "画像のアップスケールと顔補正"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/external-llm-server.md
+++ b/src/content/ja/basic-workflows/external-llm-server.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: external-llm-server
 navId: external-llm-server
 title: "外部LLMサーバ連携"
+created: 2026-02-18
+updated: 2026-03-02
 summary: "ComfyUIの外でLLMを動かし連携する"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/florence2.md
+++ b/src/content/ja/basic-workflows/florence2.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: florence2
 navId: florence2
 title: "Florence-2"
+created: 2025-12-08
+updated: 2026-03-02
 summary: "Florence-2を使った画像キャプション生成・物体検出"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/flux-1-kontext.md
+++ b/src/content/ja/basic-workflows/flux-1-kontext.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: flux-1-kontext
 navId: flux-1-kontext
 title: "Flux.1 Kontext"
+created: 2025-12-11
+updated: 2026-03-02
 summary: "Flux.1 Kontextで指示ベース画像編集を行う。"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/flux-1-tools.md
+++ b/src/content/ja/basic-workflows/flux-1-tools.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: flux-1-tools
 navId: flux-1-tools
 title: "Flux.1 Tools"
+created: 2025-12-10
+updated: 2026-03-02
 summary: "Flux.1 Toolsの使い方"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/flux-1.md
+++ b/src/content/ja/basic-workflows/flux-1.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: flux-1
 navId: flux-1
 title: "Flux.1"
+created: 2025-12-09
+updated: 2026-03-02
 summary: "Flux.1の基本とComfyUIでの使い方"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/flux-2-klein.md
+++ b/src/content/ja/basic-workflows/flux-2-klein.md
@@ -6,6 +6,8 @@ section: basic-workflows
 slug: flux-2-klein
 navId: flux-2-klein
 title: "FLUX.2 [klein]"
+created: 2026-01-22
+updated: 2026-03-02
 summary: "FLUX.2 [klein] 生成・画像編集workflow"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/joycaption.md
+++ b/src/content/ja/basic-workflows/joycaption.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: joycaption
 navId: joycaption
 title: "JoyCaption"
+created: 2025-12-08
+updated: 2026-03-02
 summary: "JoyCaptionを使った画像キャプション生成"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/ksampler-advanced.md
+++ b/src/content/ja/basic-workflows/ksampler-advanced.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: ksampler-advanced
 navId: ksampler-advanced
 title: "KSampler (Advanced)ノード"
+created: 2025-12-06
+updated: 2026-03-02
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:
   image: ""

--- a/src/content/ja/basic-workflows/liveportrait.md
+++ b/src/content/ja/basic-workflows/liveportrait.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: liveportrait
 navId: liveportrait
 title: "LivePortrait"
+created: 2025-12-12
+updated: 2026-03-02
 summary: "LivePortraitで1枚の顔写真から表情や首振りをコントロールする"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/llm-mllm.md
+++ b/src/content/ja/basic-workflows/llm-mllm.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: llm-mllm
 navId: llm-mllm
 title: "LLM / MLLM"
+created: 2026-02-18
+updated: 2026-03-27
 summary: "ComfyUIでLLMを使うと何ができるか"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/ltx-2-3.md
+++ b/src/content/ja/basic-workflows/ltx-2-3.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: ltx-2-3
 navId: ltx-2-3
 title: "LTX 2.3"
+created: 2026-03-22
+updated: 2026-04-13
 summary: "LTX 2.3: text2video / image2video / audio2video"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/ltx-2.md
+++ b/src/content/ja/basic-workflows/ltx-2.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: ltx-2
 navId: ltx-2
 title: "LTX-2"
+created: 2026-01-10
+updated: 2026-04-13
 summary: "LTX-2でtext2video / image2video / audio2videoを扱う"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/lumina-image-2.0.md
+++ b/src/content/ja/basic-workflows/lumina-image-2.0.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: lumina-image-2.0
 navId: lumina-image-2.0
 title: "Lumina-Image 2.0"
+created: 2025-12-11
+updated: 2026-03-02
 summary: "Lumina-Image 2.0の基本とComfyUIでの使い方"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/model-merge.md
+++ b/src/content/ja/basic-workflows/model-merge.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: model-merge
 navId: model-merge
 title: "モデルのマージと差分LoRA"
+created: 2025-12-11
+updated: 2026-03-02
 summary: "チェックポイントやLoRAをマージして新しいモデルや差分LoRAを作る方法"
 permalink: /{{ lang }}/{{ section }}/{{ slug }}/
 hero:

--- a/src/content/ja/basic-workflows/qwen-image-edit.md
+++ b/src/content/ja/basic-workflows/qwen-image-edit.md
@@ -6,6 +6,8 @@ section: basic-workflows
 slug: qwen-image-edit
 navId: qwen-image-edit
 title: "Qwen-Image-Edit"
+created: 2025-12-11
+updated: 2026-03-02
 summary: "Qwen-Image-Editで指示ベース画像編集を行う"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/qwen-image-layered.md
+++ b/src/content/ja/basic-workflows/qwen-image-layered.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: qwen-image-layered
 navId: qwen-image-layered
 title: "Qwen-Image-Layered"
+created: 2025-12-31
+updated: 2026-03-02
 summary: "入力画像を複数のRGBAレイヤーに分解する"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/qwen-image.md
+++ b/src/content/ja/basic-workflows/qwen-image.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: qwen-image
 navId: qwen-image
 title: "Qwen-Image"
+created: 2025-12-11
+updated: 2026-03-02
 summary: "Qwen-Imageの使い方"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/reactor.md
+++ b/src/content/ja/basic-workflows/reactor.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: reactor
 navId: reactor
 title: "ReActor"
+created: 2025-12-09
+updated: 2026-03-02
 summary: "ReActorを使ったFaceSwap（顔入れ替え）"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/sd15-basics.md
+++ b/src/content/ja/basic-workflows/sd15-basics.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-basics
 navId: sd15-basic
 title: "画像生成の基本(SD1.5)"
+created: 2025-11-13
+updated: 2026-03-02
 summary: "Stable Diffusion 1.5で学ぶ画像生成の基本"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/sd15-controlnet.md
+++ b/src/content/ja/basic-workflows/sd15-controlnet.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-controlnet
 navId: sd15-controlnet
 title: "ControlNet"
+created: 2025-12-08
+updated: 2026-03-02
 summary: "ポーズや線画を使って画像生成をコントロールする"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 tags: ["controlnet"]

--- a/src/content/ja/basic-workflows/sd15-hires-fix.md
+++ b/src/content/ja/basic-workflows/sd15-hires-fix.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-hires-fix
 navId: sd15-hires-fix
 title: "Hires.fix"
+created: 2025-12-07
+updated: 2026-03-02
 summary: "Hires.fixを使った高解像度画像生成"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/sd15-image2image.md
+++ b/src/content/ja/basic-workflows/sd15-image2image.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-image2image
 navId: sd15-image2image
 title: "image2image"
+created: 2025-12-06
+updated: 2026-03-02
 summary: "Stable Diffusion 1.5で学ぶimage2image"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/sd15-inpainting.md
+++ b/src/content/ja/basic-workflows/sd15-inpainting.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-inpainting
 navId: sd15-inpainting
 title: "inpainting"
+created: 2025-12-07
+updated: 2026-03-02
 summary: "inpaintingで画像の一部分だけ編集する"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 tags: ["controlnet", "region-limited-generation"]

--- a/src/content/ja/basic-workflows/sd15-ip-adapter.md
+++ b/src/content/ja/basic-workflows/sd15-ip-adapter.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-ip-adapter
 navId: sd15-ip-adapter
 title: "IP-Adapter"
+created: 2025-12-08
+updated: 2026-03-02
 summary: "参照画像からスタイルや被写体を転送する元祖的な仕組み"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/sd15-lora.md
+++ b/src/content/ja/basic-workflows/sd15-lora.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-lora
 navId: sd15-lora
 title: "LoRA"
+created: 2025-12-05
+updated: 2026-03-02
 summary: "Stable Diffusion 1.5でのLoRA"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/sd15-outpainting.md
+++ b/src/content/ja/basic-workflows/sd15-outpainting.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-outpainting
 navId: sd15-outpainting
 title: "outpainting"
+created: 2025-12-07
+updated: 2026-03-02
 summary: "outpaintingで画像の外側を描き足す"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/sd15-text2image.md
+++ b/src/content/ja/basic-workflows/sd15-text2image.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-text2image
 navId: sd15-text2image
 title: "text2image"
+created: 2025-12-04
+updated: 2026-03-02
 summary: "Stable Diffusion 1.5でのtext2image"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/sd15-textual-inversion.md
+++ b/src/content/ja/basic-workflows/sd15-textual-inversion.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-textual-inversion
 navId: sd15-textual-inversion
 title: "Textual Inversion"
+created: 2025-12-05
+updated: 2026-03-02
 summary: "Stable Diffusion 1.5でのTextual Inversion"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/sdxl-anime.md
+++ b/src/content/ja/basic-workflows/sdxl-anime.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sdxl-anime
 navId: sdxl-anime
 title: "アニメ系 SDXL モデル"
+created: 2025-12-09
+updated: 2026-03-02
 summary: "SDXLベースのアニメ系モデルのざっくり整理"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/sdxl.md
+++ b/src/content/ja/basic-workflows/sdxl.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sdxl
 navId: sdxl
 title: "SDXL"
+created: 2025-12-09
+updated: 2026-03-02
 summary: "SDXLの使い方"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/speed-and-efficiency.md
+++ b/src/content/ja/basic-workflows/speed-and-efficiency.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: speed-and-efficiency
 navId: speed-and-efficiency
 title: "高速化と軽量化"
+created: 2025-12-11
+updated: 2026-03-02
 summary: "拡散モデルの高速化・軽量化技術を整理して目的別に使い分ける"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/ultimate-sd-upscale.md
+++ b/src/content/ja/basic-workflows/ultimate-sd-upscale.md
@@ -6,6 +6,8 @@ section: basic-workflows
 slug: ultimate-sd-upscale
 navId: ultimate-sd-upscale
 title: "Ultimate SD upscale"
+created: 2025-12-08
+updated: 2026-03-02
 summary: "TileとControlNetを使った超高解像度アップスケール"
 permalink: "/{{ lang }}/basic-workflows/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/wan-2-1-vace.md
+++ b/src/content/ja/basic-workflows/wan-2-1-vace.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: wan-2-1-vace
 navId: wan-2-1-vace
 title: "Wan2.1 VACE"
+created: 2025-12-13
+updated: 2026-03-02
 summary: "Wan2.1 VACEでControlNet的制御・in/outpainting・reference2video・Extensionを扱う"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/wan-2-1.md
+++ b/src/content/ja/basic-workflows/wan-2-1.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: wan-2-1
 navId: wan-2-1
 title: "Wan2.1"
+created: 2025-12-12
+updated: 2026-03-02
 summary: "Wan2.1でtext2video・image2video・FLF2Vを扱う基本workflow"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/wan-2-2.md
+++ b/src/content/ja/basic-workflows/wan-2-2.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: wan-2-2
 navId: wan-2-2
 title: "Wan2.2"
+created: 2025-12-12
+updated: 2026-03-02
 summary: "Wan2.2でtext2video / image2video / FLF2Vを使った動画生成"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/wan-animate.md
+++ b/src/content/ja/basic-workflows/wan-animate.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: wan-animate
 navId: wan-animate
 title: "Wan-Animate"
+created: 2025-12-12
+updated: 2026-03-02
 summary: "Wan-Animateで人物・キャラへのモーション転送を行う"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/z-image-turbo.md
+++ b/src/content/ja/basic-workflows/z-image-turbo.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: z-image-turbo
 navId: z-image-turbo
 title: "Z-Image-Turbo"
+created: 2025-12-12
+updated: 2026-03-02
 summary: "Z-Image-Turboでの画像生成"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/ja/basic-workflows/z-image.md
+++ b/src/content/ja/basic-workflows/z-image.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: z-image
 navId: z-image
 title: "Z-Image"
+created: 2026-01-31
+updated: 2026-03-02
 summary: "Z-Imageでの画像生成"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/ace-plus-plus.md
+++ b/src/content/zh/basic-workflows/ace-plus-plus.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: ace-plus-plus
 navId: ace-plus-plus
 title: "ACE++"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "用 ACE++ 扩展 Flux.1 Fill"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/api-nodes.md
+++ b/src/content/zh/basic-workflows/api-nodes.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: api-nodes
 navId: api-nodes
 title: "API 节点"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "在 ComfyUI 的 API 节点利用外部的封闭模型的方法"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/auraflow.md
+++ b/src/content/zh/basic-workflows/auraflow.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: auraflow
 navId: auraflow
 title: "AuraFlow"
+created: 2025-12-09
+updated: 2026-03-02
 summary: "AuraFlow 和 Pony V7 的粗略整理"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/chroma1-hd.md
+++ b/src/content/zh/basic-workflows/chroma1-hd.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: chroma1-hd
 navId: chroma1-hd
 title: "Chroma1-HD"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "用 Chroma1-HD 扩展 Flux.1-schnell"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/controlnet-prep.md
+++ b/src/content/zh/basic-workflows/controlnet-prep.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: controlnet-prep
 navId: controlnet-prep
 title: "ControlNet 预处理器"
+created: 2025-12-08
+updated: 2026-03-02
 summary: "制作在 ControlNet 使用的辅助图像"
 tags: ["controlnet"]
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"

--- a/src/content/zh/basic-workflows/detailer.md
+++ b/src/content/zh/basic-workflows/detailer.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: detailer
 navId: detailer
 title: "Detailer"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "只切出小脸和细部进行 inpaint 的机制"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/differential-diffusion.md
+++ b/src/content/zh/basic-workflows/differential-diffusion.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: differential-diffusion
 navId: differential-diffusion
 title: "Differential Diffusion"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "用掩膜的浓度控制变化量"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/esrgan.md
+++ b/src/content/zh/basic-workflows/esrgan.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: esrgan
 navId: esrgan
 title: "ESRGAN"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "图像的放大和面部修正"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/external-llm-server.md
+++ b/src/content/zh/basic-workflows/external-llm-server.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: external-llm-server
 navId: external-llm-server
 title: "外部 LLM 服务器集成"
+created: 2026-02-18
+updated: 2026-03-02
 summary: "在 ComfyUI 外部运行 LLM 并与其联动"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/florence2.md
+++ b/src/content/zh/basic-workflows/florence2.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: florence2
 navId: florence2
 title: "Florence-2"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "使用 Florence-2 的图像说明文生成・物体检出"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/flux-1-kontext.md
+++ b/src/content/zh/basic-workflows/flux-1-kontext.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: flux-1-kontext
 navId: flux-1-kontext
 title: "Flux.1 Kontext"
+created: 2025-12-11
+updated: 2026-03-02
 summary: "在 Flux.1 Kontext 中进行指令基础的图像编辑。"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/flux-1-tools.md
+++ b/src/content/zh/basic-workflows/flux-1-tools.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: flux-1-tools
 navId: flux-1-tools
 title: "Flux.1 Tools"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "Flux.1 Tools 的使用方法"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/flux-1.md
+++ b/src/content/zh/basic-workflows/flux-1.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: flux-1
 navId: flux-1
 title: "Flux.1"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "Flux.1 的基础和在 ComfyUI 中的使用方法"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/flux-2-klein.md
+++ b/src/content/zh/basic-workflows/flux-2-klein.md
@@ -6,6 +6,8 @@ section: basic-workflows
 slug: flux-2-klein
 navId: flux-2-klein
 title: "FLUX.2 [klein]"
+created: 2026-01-22
+updated: 2026-03-02
 summary: "FLUX.2 [klein] 生成・图像编辑工作流"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/joycaption.md
+++ b/src/content/zh/basic-workflows/joycaption.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: joycaption
 navId: joycaption
 title: "JoyCaption"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "使用 JoyCaption 的图像说明文生成"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/ksampler-advanced.md
+++ b/src/content/zh/basic-workflows/ksampler-advanced.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: ksampler-advanced
 navId: ksampler-advanced
 title: "KSampler (Advanced) 节点"
+created: 2026-02-06
+updated: 2026-03-02
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:
   image: ""

--- a/src/content/zh/basic-workflows/liveportrait.md
+++ b/src/content/zh/basic-workflows/liveportrait.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: liveportrait
 navId: liveportrait
 title: "LivePortrait"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "在 LivePortrait 中从 1 张脸部照片控制表情和摇头"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/llm-mllm.md
+++ b/src/content/zh/basic-workflows/llm-mllm.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: llm-mllm
 navId: llm-mllm
 title: "LLM / MLLM"
+created: 2026-02-18
+updated: 2026-03-27
 summary: "在 ComfyUI 中使用 LLM 能做什么"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/ltx-2-3.md
+++ b/src/content/zh/basic-workflows/ltx-2-3.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: ltx-2-3
 navId: ltx-2-3
 title: "LTX 2.3"
+created: 2026-03-22
+updated: 2026-04-13
 summary: "在 LTX 2.3 中处理 text2video、image2video、audio2video 和 audio-image2video"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/ltx-2.md
+++ b/src/content/zh/basic-workflows/ltx-2.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: ltx-2
 navId: ltx-2
 title: "LTX-2"
+created: 2026-02-06
+updated: 2026-04-13
 summary: "在 LTX-2 中处理 text2video / image2video / audio2video"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/lumina-image-2.0.md
+++ b/src/content/zh/basic-workflows/lumina-image-2.0.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: lumina-image-2.0
 navId: lumina-image-2.0
 title: "Lumina-Image 2.0"
+created: 2025-12-11
+updated: 2026-03-02
 summary: "Lumina-Image 2.0 的基础和在 ComfyUI 中的使用方法"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/model-merge.md
+++ b/src/content/zh/basic-workflows/model-merge.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: model-merge
 navId: model-merge
 title: "模型合并与差分 LoRA"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "合并检查点或 LoRA 制作新模型或差分 LoRA 的方法"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/qwen-image-edit.md
+++ b/src/content/zh/basic-workflows/qwen-image-edit.md
@@ -6,6 +6,8 @@ section: basic-workflows
 slug: qwen-image-edit
 navId: qwen-image-edit
 title: "Qwen-Image-Edit"
+created: 2025-12-11
+updated: 2026-03-02
 summary: "用 Qwen-Image-Edit 进行基于指示的图像编辑"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/qwen-image-layered.md
+++ b/src/content/zh/basic-workflows/qwen-image-layered.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: qwen-image-layered
 navId: qwen-image-layered
 title: "Qwen-Image-Layered"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "将输入图像分解为复数的 RGBA 图层"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/qwen-image.md
+++ b/src/content/zh/basic-workflows/qwen-image.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: qwen-image
 navId: qwen-image
 title: "Qwen-Image"
+created: 2025-12-11
+updated: 2026-03-02
 summary: "Qwen-Image 的使用方法"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/reactor.md
+++ b/src/content/zh/basic-workflows/reactor.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: reactor
 navId: reactor
 title: "ReActor"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "使用 ReActor 的 FaceSwap（变脸）"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/sd15-basics.md
+++ b/src/content/zh/basic-workflows/sd15-basics.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-basics
 navId: sd15-basics
 title: "图像生成的基础(SD1.5)"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "在 Stable Diffusion 1.5 中学习图像生成的基础"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/sd15-controlnet.md
+++ b/src/content/zh/basic-workflows/sd15-controlnet.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-controlnet
 navId: sd15-controlnet
 title: "ControlNet"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "使用姿势或线稿控制图像生成"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 tags: ["controlnet"]

--- a/src/content/zh/basic-workflows/sd15-hires-fix.md
+++ b/src/content/zh/basic-workflows/sd15-hires-fix.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-hires-fix
 navId: sd15-hires-fix
 title: "Hires.fix"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "使用 Hires.fix 生成高分辨率图像"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/sd15-image2image.md
+++ b/src/content/zh/basic-workflows/sd15-image2image.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-image2image
 navId: sd15-image2image
 title: "image2image"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "在 Stable Diffusion 1.5 中学习 image2image"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/sd15-inpainting.md
+++ b/src/content/zh/basic-workflows/sd15-inpainting.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-inpainting
 navId: sd15-inpainting
 title: "inpainting"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "用 inpainting 只编辑图像的一部分"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 tags: ["controlnet", "region-limited-generation"]

--- a/src/content/zh/basic-workflows/sd15-ip-adapter.md
+++ b/src/content/zh/basic-workflows/sd15-ip-adapter.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-ip-adapter
 navId: sd15-ip-adapter
 title: "IP-Adapter"
+created: 2025-12-09
+updated: 2026-03-02
 summary: "从参照图像转印风格和被摄体的元祖机制"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/sd15-lora.md
+++ b/src/content/zh/basic-workflows/sd15-lora.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-lora
 navId: sd15-lora
 title: "LoRA"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "Stable Diffusion 1.5 的 LoRA"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/sd15-outpainting.md
+++ b/src/content/zh/basic-workflows/sd15-outpainting.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-outpainting
 navId: sd15-outpainting
 title: "outpainting"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "用 outpainting 扩画图像的外侧"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/sd15-text2image.md
+++ b/src/content/zh/basic-workflows/sd15-text2image.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-text2image
 navId: sd15-text2image
 title: "text2image"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "Stable Diffusion 1.5 的 text2image"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:
@@ -143,9 +145,9 @@ hero:
 虽然被理所当然地对待，但仔细一想，有一些是图像生成特有的、不可思议的东西。  
 关于这些在别的页面简单地进行了解说。
 
-  - [即使使用相同的参数，Stable Diffusion web UI 和 ComfyUI 也无法生成相同的图像](/zh/faq/sdwebui-comfyui-reproducibility/)
-  - [为什么生成 512px × 512px？](/zh/faq/why-512px/)
-  - [为什么只能生成 8 的倍数的分辨率？](/zh/faq/why-multiple-of-8/)
+  - [即使使用相同的参数，Stable Diffusion web UI 和 ComfyUI 也无法生成相同的图像](/zh/notes/sdwebui-comfyui-reproducibility/)
+  - [为什么生成 512px × 512px？](/zh/notes/why-512px/)
+  - [为什么只能生成 8 的倍数的分辨率？](/zh/notes/why-multiple-of-8/)
   - Seed 值 "1234" 和 "1235" 是完全不同的东西（待补链接）
 
 ---

--- a/src/content/zh/basic-workflows/sd15-textual-inversion.md
+++ b/src/content/zh/basic-workflows/sd15-textual-inversion.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sd15-textual-inversion
 navId: sd15-textual-inversion
 title: "Textual Inversion"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "Stable Diffusion 1.5 的 Textual Inversion"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/sdxl-anime.md
+++ b/src/content/zh/basic-workflows/sdxl-anime.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sdxl-anime
 navId: sdxl-anime
 title: "动漫系 SDXL 模型"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "SDXL 基础的动漫系模型的粗略整理"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/sdxl.md
+++ b/src/content/zh/basic-workflows/sdxl.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: sdxl
 navId: sdxl
 title: "SDXL"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "SDXL 的使用方法"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/speed-and-efficiency.md
+++ b/src/content/zh/basic-workflows/speed-and-efficiency.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: speed-and-efficiency
 navId: speed-and-efficiency
 title: "高速化与轻量化"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "整理扩散模型的高速化・轻量化技术并按目的区分使用"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/ultimate-sd-upscale.md
+++ b/src/content/zh/basic-workflows/ultimate-sd-upscale.md
@@ -6,6 +6,8 @@ section: basic-workflows
 slug: ultimate-sd-upscale
 navId: ultimate-sd-upscale
 title: "Ultimate SD upscale"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "使用 Tile 和 ControlNet 的超高分辨率放大"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/wan-2-1-vace.md
+++ b/src/content/zh/basic-workflows/wan-2-1-vace.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: wan-2-1-vace
 navId: wan-2-1-vace
 title: "Wan2.1 VACE"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "在 Wan2.1 VACE 中处理 ControlNet 式控制・in/outpainting・reference2video・Extension"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/wan-2-1.md
+++ b/src/content/zh/basic-workflows/wan-2-1.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: wan-2-1
 navId: wan-2-1
 title: "Wan2.1"
+created: 2025-12-12
+updated: 2026-03-02
 summary: "在 Wan2.1 中处理 text2video・image2video・FLF2V 的基本工作流"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/wan-2-2.md
+++ b/src/content/zh/basic-workflows/wan-2-2.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: wan-2-2
 navId: wan-2-2
 title: "Wan2.2"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "在 Wan2.2 中使用 text2video / image2video / FLF2V 的视频生成"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/wan-animate.md
+++ b/src/content/zh/basic-workflows/wan-animate.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: wan-animate
 navId: wan-animate
 title: "Wan-Animate"
+created: 2026-02-06
+updated: 2026-03-02
 summary: "在 Wan-Animate 中进行向人物・角色的动作传送"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/z-image-turbo.md
+++ b/src/content/zh/basic-workflows/z-image-turbo.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: z-image-turbo
 navId: z-image-turbo
 title: "Z-Image-Turbo"
+created: 2025-12-12
+updated: 2026-03-02
 summary: "使用 Z-Image-Turbo 的图像生成"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:

--- a/src/content/zh/basic-workflows/z-image.md
+++ b/src/content/zh/basic-workflows/z-image.md
@@ -5,6 +5,8 @@ section: basic-workflows
 slug: z-image
 navId: z-image
 title: "Z-Image"
+created: 2026-01-31
+updated: 2026-03-02
 summary: "使用 Z-Image 的图像生成"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:


### PR DESCRIPTION
## Summary

- add `created` / `updated` metadata to Basic Workflow pages across `ja`, `en`, and `zh`
- update remaining touched Chinese SD15 text2image links from old `/faq/` paths to `/notes/`

## Notes

This is the final metadata-only follow-up split from the larger date metadata backup branch so the PR stays under the CodeRabbit file limit.

## Validation

- `npm run build`
