### PR TITLE
[codex] Document agent state workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ coverage/
 tmp/
 test-results/
 playwright-report/
+AGENT_STATE.md
 
 # Mock assets (large reference images only)
 src/assets/mock/**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,3 +267,22 @@ No custom encoding helpers, no codepage manipulation, no guessing.
 
 
 Agents should reuse these exact patterns (with path and content substituted) rather than inventing ad-hoc file I/O commands.
+
+
+---
+
+## 14. Agent Instructions
+
+Before starting work, read `AGENT_STATE.md` if it exists.
+
+When you finish a meaningful step, update `AGENT_STATE.md` with:
+- current goal
+- files changed
+- checks run
+- next action
+- blockers
+
+Do not rely on chat history as the source of truth.
+
+`AGENT_STATE.md` is a local working-memory file and should not be committed.
+Use `AGENT_STATE.example.md` as the shared template.

--- a/AGENT_STATE.example.md
+++ b/AGENT_STATE.example.md
@@ -1,0 +1,7 @@
+# Agent State
+
+- current goal:
+- files changed:
+- checks run:
+- next action:
+- blockers:

--- a/ops/principles.md
+++ b/ops/principles.md
@@ -41,3 +41,9 @@
 - 1 PR = 1 intent (e.g., “app shell” or “search”), with mock-compliance screenshots attached.
 - Document breaking questions as issues linked from `/ops`; never patch around ambiguity.
 - Keep change logs in the PR description; this file should summarize enduring rules, not per-PR notes.
+
+## 8. Agent Working Memory
+- Agents must read `AGENT_STATE.md` at startup if it exists, then update it after meaningful steps.
+- `AGENT_STATE.md` is local working memory and must stay out of git.
+- The shared contract lives in `AGENTS.md`; the shared template lives in `AGENT_STATE.example.md`.
+- Durable project decisions still belong in `/ops` and ADRs, not in `AGENT_STATE.md`.


### PR DESCRIPTION
## Summary

- Ignore the mutable local `AGENT_STATE.md` working-memory file.
- Add `AGENT_STATE.example.md` as the shared template.
- Clarify the agent-state workflow in `AGENTS.md` and `/ops/principles.md`.

## Why

Direct agent handoffs should not depend on chat history, but the live state file changes too often to be useful as tracked project history. This keeps the convention shared while leaving the current state local.

## Validation

- Ran `git diff --check`.
- No site build was run because this only changes agent/process documentation and git ignore rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidelines and templates for agent working memory practices to standardize development workflow coordination.

* **Chores**
  * Updated Git configuration to manage local working state files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nomadoor/Comfy-with-ComfyUI/pull/89?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->