### PR TITLE
Add FLUX.2 [klein] Schematic LoRA note

### DIFF
--- a/ops/adr/2026-06-01-flux2-klein-schematic-lora-note.md
+++ b/ops/adr/2026-06-01-flux2-klein-schematic-lora-note.md
@@ -20,4 +20,4 @@ Use the existing flat Notes structure and `noteTags`, without adding a sidebar n
 
 - The article is discoverable through Notes and Note finder.
 - No workflow JSON is required at this stage.
-- English and Chinese versions are not added until the owner requests translation sync.
+- English and Chinese versions were added after the owner explicitly requested translation sync.

--- a/ops/adr/2026-06-01-flux2-klein-schematic-lora-note.md
+++ b/ops/adr/2026-06-01-flux2-klein-schematic-lora-note.md
@@ -19,5 +19,5 @@ Use the existing flat Notes structure and `noteTags`, without adding a sidebar n
 ## Consequences
 
 - The article is discoverable through Notes and Note finder.
-- No workflow JSON is required at this stage.
+- A workflow JSON was later delivered with the PR at `src/workflows/notes/flux2-klein-schematic-lora/Flux.2-klein-base-9b_image-edit.json`.
 - English and Chinese versions were added after the owner explicitly requested translation sync.

--- a/ops/adr/2026-06-01-flux2-klein-schematic-lora-note.md
+++ b/ops/adr/2026-06-01-flux2-klein-schematic-lora-note.md
@@ -1,0 +1,23 @@
+# 2026-06-01: Add FLUX.2 Klein Schematic LoRA Note
+
+## Status
+
+Accepted
+
+## Context
+
+The owner created a new LoRA experiment for FLUX.2 [klein] that learns RGB outputs resembling computer-vision task maps. The article is an experiment note rather than a reusable workflow recipe.
+
+## Decision
+
+Add a Japanese note at:
+
+- `/ja/notes/flux2-klein-schematic-lora/`
+
+Use the existing flat Notes structure and `noteTags`, without adding a sidebar navigation entry.
+
+## Consequences
+
+- The article is discoverable through Notes and Note finder.
+- No workflow JSON is required at this stage.
+- English and Chinese versions are not added until the owner requests translation sync.

--- a/ops/style-design.md
+++ b/ops/style-design.md
@@ -83,6 +83,7 @@ PNG mock does **not** use gradients; hero fallback stays solid charcoal.
 - Blockquotes use a quiet but visible purple-tinted background surface with small radius and a small Tabler-style info icon at the start. Do not use borders, a left accent bar, or italic styling by default.
 - Inline images are centered, `max-width: 720px`, `max-height: 320px`, and `object-fit: contain` so portrait assets never force extra scrolling.
 - Inline Gyazo media stays completely flat: **no borders / box-shadows**. When contrast is needed, rely on `--color-panel-alt` as the single backing surface.
+- Image comparison tables must stay within the article content width. Tables that contain article media use fixed column layout, compact cell padding, and equal-size square media frames; images preserve their own aspect ratio with `object-fit: contain`.
 - 蜈ｨ繝壹・繧ｸ縺ｧ蜷御ｸ繝医・繝ｳ繧剃ｿ昴▽縺溘ａ縲∵悽譁・ｸｭ縺ｮ逕ｻ蜒上・蜍慕判繧ゅョ繝輔か繝ｫ繝医〒貂帛・繝輔ぅ繝ｫ繧ｿ・井ｾ具ｼ啻filter: brightness(0.85)`・峨ｒ驕ｩ逕ｨ縺吶ｋ縲・
 - Lists use custom markers: first-level unordered lists use small accent dots, nested unordered lists use muted hollow accent dots, and ordered lists use accent numbers.
 - `.placeholder` component is dashed border block for 窶懊∪縺繝壹・繧ｸ縺後≠繧翫∪縺帙ｓ窶・states and 404 page.

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -1905,6 +1905,7 @@ h1 {
 
 .article-body table {
   width: 100%;
+  max-width: 100%;
   margin: var(--space-md) 0;
   border-collapse: collapse;
   border-spacing: 0;
@@ -1935,6 +1936,35 @@ h1 {
 
 .article-body table tbody tr+tr td {
   border-top: 1px solid var(--color-border);
+}
+
+.article-body table:has(.article-media) {
+  table-layout: fixed;
+}
+
+.article-body table:has(.article-media) th,
+.article-body table:has(.article-media) td {
+  padding: var(--space-xs);
+  vertical-align: top;
+}
+
+.article-body table:has(.article-media) .article-media {
+  margin: 0;
+}
+
+.article-body table:has(.article-media) .article-media__frame {
+  width: 100%;
+  max-width: 100%;
+  height: auto;
+  min-height: 0;
+  max-height: none;
+  aspect-ratio: 1 / 1;
+}
+
+.article-body table:has(.article-media) .article-media__frame img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 .article-body table td:first-child code,

--- a/src/content/en/news.md
+++ b/src/content/en/news.md
@@ -5,7 +5,7 @@ slug: news
 navId: news
 title: "News"
 created: 2026-01-15
-updated: 2026-05-29
+updated: 2026-06-01
 summary: "Site updates"
 permalink: "/{{ lang }}/{{ slug }}/"
 tags:
@@ -13,6 +13,11 @@ tags:
 ---
 
 <div class="news-list">
+  <a class="news-row" href="/en/notes/flux2-klein-schematic-lora/">
+    <span class="news-row__date">2026.6.1</span>
+    <span class="news-row__tag">notes</span>
+    <span class="news-row__title">Added FLUX.2 [klein] Schematic LoRA page</span>
+  </a>
   <a class="news-row" href="/en/basic-workflows/anima/">
     <span class="news-row__date">2026.5.29</span>
     <span class="news-row__tag">basic-workflows</span>

--- a/src/content/en/notes/flux2-klein-schematic-lora.md
+++ b/src/content/en/notes/flux2-klein-schematic-lora.md
@@ -1,0 +1,363 @@
+---
+layout: page.njk
+lang: en
+section: notes
+slug: flux2-klein-schematic-lora
+navId: flux2-klein-schematic-lora
+title: "FLUX.2 [klein] Schematic LoRA"
+created: 2026-05-30
+updated: 2026-06-01
+noteTags: ["project", "flux-2-klein", "lora"]
+summary: "Training FLUX.2 [klein] to produce CV-task-like RGB outputs"
+permalink: "/{{ lang }}/notes/{{ slug }}/"
+hero:
+  image: "https://i.gyazo.com/a0dc0970df98429dcf703e3ed095f6fa.png"
+---
+
+## Overview
+
+![](https://gyazo.com/2bd9f7b01d61bea0658ba82a750f227e){gyazo=image}
+
+There are many studies that reuse the prior knowledge of image generation models for CV tasks. Representative examples include [Marigold](https://arxiv.org/abs/2312.02145), [Lotus-2](https://huggingface.co/papers/2512.01030), and [SDPose](https://tsliang.top/SDPose/).
+
+Although these methods use pretrained image generation models, they are ultimately designed specifically for each task.
+
+Now that instruction-based image editing models have become common, another idea has appeared: maybe tasks such as depth estimation and segmentation can be treated, in a broad sense, as **image editing**. That is the idea behind Google DeepMind's [Vision Banana](https://vision-banana.github.io/).
+
+Inspired by that direction, I wanted to see whether something similar could be done with FLUX.2 [klein].
+
+The result is not SOTA-level performance. Still, I hope this experiment shows that even a simple LoRA can make a local model behave in a direction somewhat close to Vision Banana.
+
+---
+
+## Task Setup
+
+Vision Banana mainly covers depth / normal / segmentation.
+
+For this experiment, I did not use exactly the same task set. Instead, I chose outputs that are familiar in ComfyUI and the image generation community, roughly like ControlNet Preprocessor outputs.
+
+Personally, I call these tasks `image2schematic`, and every LoRA created for this experiment includes the word `schematic`.
+
+| task | output |
+|---|---|
+| relative depth | near = white / far = black |
+| normal map | RGB normal map |
+| pose body | OpenPose-style body skeleton |
+| pose full | body + hands + face |
+| binary segmentation | visible region mask |
+| amodal segmentation | mask including occluded parts |
+
+### amodal segmentation
+
+![](https://gyazo.com/a0cf18a91c6349d3d3002fe98453b723){gyazo=image}
+
+Some readers may not be familiar with amodal segmentation.
+
+- Regular segmentation masks only the **visible region** of the target.
+- Amodal segmentation estimates and masks the full shape of the target, including parts hidden behind occluders.
+
+For example, if branches are blocking a deer, regular segmentation will not output the parts hidden behind the branches.  
+With amodal segmentation, the mask includes the full deer, including the hidden parts.
+
+Because it has to infer invisible regions, this is closer to generation than simple classification.  
+In that sense, it is also a task where an image generation model may be able to show its strengths, so I decided to try it.
+
+### One LoRA Per Task
+
+At first, I planned to train all tasks into a single LoRA, but the tasks mixed internally and could not be switched well with prompts alone.
+
+So this experiment uses one LoRA per task.
+
+---
+
+## Dataset
+
+| task | positive | negative | total |
+|---|---:|---:|---:|
+| depth | 300 | 0 | 300 |
+| normal | 300 | 0 | 300 |
+| pose body | 300 | 30 | 330 |
+| pose full | 300 | 30 | 330 |
+| binary segmentation | 300 | 30 | 330 |
+| amodal segmentation | 300 | 30 | 330 |
+
+### Depth / Normal
+
+Images were taken from Open Images, and the teacher outputs were created with Lotus-2.
+
+- depth
+  - relative depth
+  - near = white
+  - far = black
+- normal
+  - RGB normal map
+
+Depth and normal use the same input image set.
+
+### Pose
+
+Person images were taken from Open Images, and the teacher outputs were created with DWPose.
+
+- pose body
+- pose full
+
+Candidate images were reviewed manually, and crowded images or obviously broken outputs were removed.
+
+### Amodal Segmentation
+
+Amodal segmentation is a task that creates a mask for the whole object, including not only the visible area but also parts hidden by occluders.
+
+I did not have an existing dataset or a teacher that could directly generate this, so I created it by combining image generation and image editing.
+
+Creation flow:
+
+1. GPT-5.5 created prompts for occlusion scenes with a clear subject and a natural occluder
+2. Z-Image-Turbo generated the source image
+3. GPT-5.5 reviewed the source image
+4. FLUX.2 [klein] 9B image edit removed the occluder
+5. SAM 3.1 segmented the target object from the edited image
+6. The source image and complete-object mask were paired
+7. Manual review
+8. Refinement with BiRefNet and manual editing
+
+SAM 3.1 alone was unstable for these masks, so almost all of them were fixed with BiRefNet and manual edits.
+
+This is not the main point, but when an LLM generates large numbers of image prompts, the results tend to converge toward:
+
+- similar subjects
+- similar occluders
+- similar compositions
+
+To avoid that, I showed random Open Images examples as inspiration and increased the scene variation.
+
+### Binary Segmentation
+
+The source images created for amodal segmentation were reused.
+
+The actually visible target object region in the input image was segmented with SAM 3.1 and refined manually.
+
+### Negative Samples
+
+For both pose and segmentation, hallucination becomes a problem when the requested target is not present in the input image.
+
+For example, if there is no cat in the input image but the prompt says `generate mask of the cat`, the model may invent a cat-shaped mask.
+
+To address this, I added some negative pairs with all-black targets.
+
+- segmentation
+  - If the specified target does not exist in the image, return an all-black mask
+  - Example: asking for a `cat` amodal mask when the conditioning image only contains a giraffe
+- pose
+  - If no person appears in the input image, return an all-black pose image
+
+However, at this scale, I could not confirm a clear improvement. For pose in particular, it may have made training less stable.
+
+---
+
+## Training
+
+Training was done with [AI Toolkit](https://github.com/ostris/ai-toolkit).
+
+| item | value |
+|---|---|
+| base model | `black-forest-labs/FLUX.2-klein-base-9B` |
+| architecture | `flux2_klein_9b` |
+| LoRA rank | linear 32 / conv 16 |
+| optimizer | `adamw8bit` |
+| lr | `5e-5` |
+| dtype | `bf16` |
+| quantization | transformer / text encoder: `qfloat8` |
+| batch size | 4 |
+| text encoder | frozen |
+| caption dropout | 0.05 |
+| EMA | enabled |
+
+To keep the compute cost down, I basically used a 768 bucket.
+
+Only pose full was trained with both 768 / 1024 buckets, because details in the face and hands matter more.
+
+Checkpoints were saved every 100 steps.  
+I tested them in ComfyUI and picked the step that looked best. All LoRAs converged at around 2000-2500 steps.
+
+---
+
+## workflow
+
+This is the workflow for using the LoRAs in ComfyUI.
+
+Note that LoRAs trained on FLUX.2 [klein] Base do not work well with the FLUX.2 [klein] Distilled model. Use the Base model, or use a Base-to-Distilled difference LoRA such as [Klein 4B/9B Base to Turbo Lora](https://civitai.com/models/2324315/klein-4b9b-base-to-turbo-lora?modelVersionId=2617121).
+
+### Model Download
+
+The base is [FLUX.2 [klein]](/en/basic-workflows/flux-2-klein/).
+
+- LoRA
+  - [flux2-klein-schematic-relative-depth-lora.safetensors](https://huggingface.co/nomadoor/flux-2-klein-9B-schematic-lora/blob/main/loras/flux2-klein-schematic-relative-depth-lora.safetensors)
+  - [flux2-klein-schematic-surface-normal-lora.safetensors](https://huggingface.co/nomadoor/flux-2-klein-9B-schematic-lora/blob/main/loras/flux2-klein-schematic-surface-normal-lora.safetensors)
+  - [flux2-klein-schematic-body-pose-lora.safetensors](https://huggingface.co/nomadoor/flux-2-klein-9B-schematic-lora/blob/main/loras/flux2-klein-schematic-body-pose-lora.safetensors)
+  - [flux2-klein-schematic-full-pose-lora.safetensors](https://huggingface.co/nomadoor/flux-2-klein-9B-schematic-lora/blob/main/loras/flux2-klein-schematic-full-pose-lora.safetensors)
+  - [flux2-klein-schematic-binary-segmentation-lora.safetensors](https://huggingface.co/nomadoor/flux-2-klein-9B-schematic-lora/blob/main/loras/flux2-klein-schematic-binary-segmentation-lora.safetensors)
+  - [flux2-klein-schematic-amodal-segmentation-lora.safetensors](https://huggingface.co/nomadoor/flux-2-klein-9B-schematic-lora/blob/main/loras/flux2-klein-schematic-amodal-segmentation-lora.safetensors)
+
+```text
+📂ComfyUI/
+└── 📂models/
+    └── 📂loras/
+        ├── flux2-klein-schematic-relative-depth-lora.safetensors
+        ├── flux2-klein-schematic-surface-normal-lora.safetensors
+        ├── flux2-klein-schematic-body-pose-lora.safetensors
+        ├── flux2-klein-schematic-full-pose-lora.safetensors
+        ├── flux2-klein-schematic-binary-segmentation-lora.safetensors
+        └── flux2-klein-schematic-amodal-segmentation-lora.safetensors
+```
+
+### image edit Base
+
+![](https://gyazo.com/596669219726f35c5106037b4fce9e38){gyazo=image}
+
+[](/workflows/notes/flux2-klein-schematic-lora/Flux.2-klein-base-9b_image-edit.json)
+
+---
+
+## Practical Tests
+
+### relative depth
+
+```text
+Generate a relative depth map of the input image.
+```
+
+| input | Depth Anything V2 | FLUX.2 [klein] LoRA |
+|---|---|---|
+| ![](https://gyazo.com/668960b4d9147ef1260a01957f93ce9a){gyazo=image} | ![](https://gyazo.com/20a4dcedf04be910c3dbf0830a34cd02){gyazo=image} | ![](https://gyazo.com/8d011d8f92dfaea759907a6430493d63){gyazo=image} |
+| ![](https://gyazo.com/206992247684d3cc8540037dffe4b088){gyazo=image} | ![](https://gyazo.com/1b39fbf77eb003a1aa38ce800728eb58){gyazo=image} | ![](https://gyazo.com/6e27345a2ecf071e40671ca000fd84f9){gyazo=image} |
+| ![](https://gyazo.com/0ec98b233b467a27a1ac497d2ccf02f9){gyazo=image} | ![](https://gyazo.com/7b1501385098f7cc43354a257739a069){gyazo=image} | ![](https://gyazo.com/ef6402a1b2562118d88f6c471e00bbc0){gyazo=image} |
+
+### normal map
+
+```text
+Generate a surface normal map of the input image.
+```
+
+| input | Lotus-2 | FLUX.2 [klein] LoRA |
+|---|---|---|
+| ![](https://gyazo.com/b3a1684aefa305aacdc41d92ea4c3485){gyazo=image} | ![](https://gyazo.com/a75bc8fdb2794f16d264f8da33dcd7cc){gyazo=image} | ![](https://gyazo.com/a1def11da46b031feabe3f0e6b3f50a2){gyazo=image} |
+| ![](https://gyazo.com/225d29e4318a97b1bfc378091cd06b0e){gyazo=image} | ![](https://gyazo.com/8cc65f987cd5dc9f277efbb242bc6a11){gyazo=image} | ![](https://gyazo.com/595aff620129e00f348fe4ebed8425c7){gyazo=image} |
+| ![](https://gyazo.com/a3566d450ba6209c256f8c55293a428c){gyazo=image} | ![](https://gyazo.com/c2aa1322ad6e17b2b900762ac63f1ba8){gyazo=image} | ![](https://gyazo.com/9f1ea3ff029395ab2d6121c059a3bc3a){gyazo=image} |
+
+### pose body
+
+```text
+Generate a body pose map of all visible people in the input image.
+```
+
+| input | DWPose | FLUX.2 [klein] LoRA |
+|---|---|---|
+| ![](https://gyazo.com/c3e372e31e394aec307a20fbb9b5fb73){gyazo=image} | ![](https://gyazo.com/5aa247ce618c608d195328483bd5f336){gyazo=image} | ![](https://gyazo.com/d503b1b89f9361c12d110e95dba909f0){gyazo=image} |
+| ![](https://gyazo.com/9ee77ec890a84129011b3ef339576171){gyazo=image} | ![](https://gyazo.com/a4a31c41ec507aa59eb0430b0eb05fc3){gyazo=image} | ![](https://gyazo.com/b06ce32e1e60019e84844b5c885f0022){gyazo=image} |
+| ![](https://gyazo.com/bd3bb102f39717b6bbfdae0cc68e96b5){gyazo=image} | ![](https://gyazo.com/5f949073e42723d6bef17932c8aa6139){gyazo=image} | ![](https://gyazo.com/5fcc24d235f0360e1284f32cf30fa9ff){gyazo=image} |
+
+### pose full
+
+```text
+Generate a full pose map of all visible people in the input image.
+```
+
+| input | DWPose | FLUX.2 [klein] LoRA |
+|---|---|---|
+| ![](https://gyazo.com/c3e372e31e394aec307a20fbb9b5fb73){gyazo=image} | ![](https://gyazo.com/cd1c92e205f413cc144b2ec534a398d3){gyazo=image} | ![](https://gyazo.com/aec346f0e8592e8f946f8c2993491955){gyazo=image} |
+| ![](https://gyazo.com/9ee77ec890a84129011b3ef339576171){gyazo=image} | ![](https://gyazo.com/90e9d09c619cbea9c8e788e7b4643616){gyazo=image} | ![](https://gyazo.com/ce5459cca85c4ec415e402d6ecf9da8f){gyazo=image} |
+| ![](https://gyazo.com/bd3bb102f39717b6bbfdae0cc68e96b5){gyazo=image} | ![](https://gyazo.com/5f949073e42723d6bef17932c8aa6139){gyazo=image} | ![](https://gyazo.com/db7abedc5ea7431d831076ce4f58353c){gyazo=image} |
+
+### binary segmentation
+
+```text
+Generate a binary segmentation mask of the stretcher in the input image.
+Generate a binary segmentation mask of the tuna sushi in the input image.
+Generate a binary segmentation mask of all jars in the input image.
+```
+
+| input | SAM 3.1 | FLUX.2 [klein] LoRA |
+|---|---|---|
+| ![](https://gyazo.com/38dd24bd0eec756210f300aa6bc22dbd){gyazo=image} | ![](https://gyazo.com/78f513b8690050f8085995e79a2bf16a){gyazo=image} | ![](https://gyazo.com/8a1faf3881821b454265ab60f7d97af0){gyazo=image} |
+| ![](https://gyazo.com/ff1760a3c6943a2e4e666ec61e1b6eab){gyazo=image} | ![](https://gyazo.com/1abbfc37a68d8335a7f66b9bed7561c3){gyazo=image} | ![](https://gyazo.com/f2ecfb80e270561e7685dfa227855c84){gyazo=image} |
+| ![](https://gyazo.com/5cc009a2cf9ed0da1a2ba74c12e1ec8c){gyazo=image} | ![](https://gyazo.com/a355a426888bd07b48efdf8ee3b6f7d7){gyazo=image} | ![](https://gyazo.com/61c49e77830d9ea82039b839cb18b38e){gyazo=image} |
+
+### amodal segmentation
+
+```text
+Generate an amodal segmentation mask of the woman in the input image.
+Generate an amodal segmentation mask of the bench in the input image.
+Generate an amodal segmentation mask of the steam locomotive in the input image.
+```
+
+| input | SAM 3.1 visible mask | FLUX.2 [klein] LoRA |
+|---|---|---|
+| ![](https://gyazo.com/6b4da57f9c240ace62c66fe6c49c49f6){gyazo=image} | ![](https://gyazo.com/ab3b4dbd6acadbe89e038d121ba011c7){gyazo=image} | ![](https://gyazo.com/79f8e50117e8bbab8dcdfee43b5d75e3){gyazo=image} |
+| ![](https://gyazo.com/3882219095ebaa6a3c148be2cd6c8cbc){gyazo=image} | ![](https://gyazo.com/34b8014d2efe1557b06403772c5c009d){gyazo=image} | ![](https://gyazo.com/fc9840c4f47858a7d52351694494c6c0){gyazo=image} |
+| ![](https://gyazo.com/4a50a286d8870c218e6c792138983ff1){gyazo=image} | ![](https://gyazo.com/95c93284e620212e59cbf261b29f21eb){gyazo=image} | ![](https://gyazo.com/4a3159526479a1ac84b9ce1bc99262d7){gyazo=image} |
+
+---
+
+## Limitations and Issues
+
+### Depth / Normal
+
+I used Lotus-2 as the teacher, but the LoRA also learned noise that came from Lotus-2.
+
+For this kind of task, synthetic data from 3D models should probably have been considered as well.
+
+As a side note, before Lotus-2, I also trained with target images created by DSINE. DSINE produces much flatter normal maps than Lotus-2, and the LoRA outputs became similarly flat.
+
+The quality of the teacher appears directly in the LoRA output, so this made me feel again how important dataset quality is.
+
+### pose
+
+The first problem is that pose is the least suited to RGB-image representation among the tasks tested here.
+
+Even if the model outputs an OpenPose-style image, converting that back into keypoints is not easy, which makes it difficult to use in practice. The colors and number of bones are also strict, so even small deviations stand out.
+
+I thought this would be an easy task to train, but it broke down more than expected. Hallucinations on animal images and non-person images are not prevented either.
+
+### segmentation
+
+I expected the prompt understanding ability of the Qwen3 8B text encoder to help, but the control was not as strong as I hoped.
+
+The model can follow instructions like "remove the person in X", but when applying the LoRA and asking it to "segment the person in X", it may fail or segment a different person.
+
+So this may not be just a problem of prompt understanding. The model may not have learned the segmentation task itself well enough from the dataset.
+
+For boundary precision, I was hoping for smoother edges closer to matting, but at the moment it remains around the roughness of SAM 3.1.
+
+### Overall
+
+Overall, the dataset size was not enough.
+
+Creating the amodal segmentation dataset was very heavy, so I roughly aligned all tasks to around 300 images.  
+To properly isolate the causes, I think each task would have needed around 2000-3000 images.
+
+There are many things left to improve, but I spent too much budget and time on this, so I am stopping here for now.  
+If I get the chance, I would like to try again with a larger dataset.
+
+---
+
+## Closing
+
+Regardless of quality, this small-scale LoRA training was enough to teach FLUX.2 [klein] some CV-task-like RGB outputs.
+
+The important point is not really whether it "can do CV tasks." It is that the possible uses of image editing models can expand quite a lot depending on **what we decide to treat as image editing**.
+
+When we hear "image editing," style transfer and object removal come to mind first.  
+But outputs like these CV-task-like images, or custom intermediate representations, can also be treated as image editing in a broad sense.
+
+It is fun to watch image generation models, which used to be mostly about drawing pictures, gradually look more like general-purpose vision models.
+
+---
+
+## References
+
+- [Marigold: Repurposing Diffusion-Based Image Generators for Monocular Depth Estimation](https://arxiv.org/abs/2312.02145)
+- [Lotus: Diffusion-based Visual Foundation Model for High-quality Dense Prediction](https://huggingface.co/papers/2409.18124)
+- [Lotus-2: Advancing Geometric Dense Prediction with Powerful Image Generative Model](https://huggingface.co/papers/2512.01030)
+- [Vision Banana: Image Generators are Generalist Vision Learners](https://arxiv.org/abs/2604.20329)
+- [Vision Banana Project Page](https://vision-banana.github.io/)

--- a/src/content/ja/news.md
+++ b/src/content/ja/news.md
@@ -5,13 +5,18 @@ slug: news
 navId: news
 title: "更新情報"
 created: 2026-01-15
-updated: 2026-05-29
+updated: 2026-06-01
 summary: "このサイトの更新情報"
 permalink: "/{{ lang }}/{{ slug }}/"
 tags:
   - news
 ---
 <div class="news-list">
+  <a class="news-row" href="/ja/notes/flux2-klein-schematic-lora/">
+    <span class="news-row__date">2026.6.1</span>
+    <span class="news-row__tag">notes</span>
+    <span class="news-row__title">FLUX.2 [klein] Schematic LoRA のページを追加しました</span>
+  </a>
   <a class="news-row" href="/ja/basic-workflows/anima/">
     <span class="news-row__date">2026.5.29</span>
     <span class="news-row__tag">basic-workflows</span>

--- a/src/content/ja/notes/flux2-klein-schematic-lora.md
+++ b/src/content/ja/notes/flux2-klein-schematic-lora.md
@@ -1,0 +1,369 @@
+---
+layout: page.njk
+lang: ja
+section: notes
+slug: flux2-klein-schematic-lora
+navId: flux2-klein-schematic-lora
+title: "FLUX.2 [klein] Schematic LoRA"
+created: 2026-05-30
+updated: 2026-06-01
+noteTags: ["project", "flux-2-klein", "lora"]
+summary: "FLUX.2 [klein] に CV タスク風の RGB 出力を学習させる"
+permalink: "/{{ lang }}/notes/{{ slug }}/"
+hero:
+  image: "https://i.gyazo.com/a0dc0970df98429dcf703e3ed095f6fa.png"
+---
+
+## 概要
+
+![](https://gyazo.com/2bd9f7b01d61bea0658ba82a750f227e){gyazo=image}
+
+画像生成モデルの事前知識を活用して、CV タスクに応用する研究はいくつもあります。代表的なものでいえば、[Marigold](https://arxiv.org/abs/2312.02145)、[Lotus-2](https://huggingface.co/papers/2512.01030)、[SDPose](https://tsliang.top/SDPose/) などです。
+
+これらは事前学習済みの画像生成モデルを利用しているとはいえ、最終的にはそれぞれのタスク専用に設計されています。
+
+しかし、指示ベース画像編集モデルが一般的になった現在、画像から深度推定やセグメンテーションを行うタスクを、大きな意味で **画像編集** として扱ってしまえば良いのではないか？という研究が発表されました。それが Google DeepMind の [Vision Banana](https://vision-banana.github.io/) です。
+
+これにインスピレーションを受け、同じ方向のことが FLUX.2 [klein] でもできないか？と考えたのが今回の実験の動機です。
+
+結果として SOTA 性能を出せたとは言えませんが、簡単な LoRA 学習だけでも、ローカルモデルで Vision Banana に近い方向の挙動を試せることを示せればと思います。
+
+---
+
+## タスク設定
+
+Vision Banana では、主に depth / normal / segmentation が扱われています。
+
+今回はそれとまったく同じタスク構成にはせず、ComfyUI / 画像生成コミュニティでなじみのある、いわゆる ControlNet Preprocessor 的な出力を中心に選出しました。
+
+個人的にこれらのタスクを `image2schematic` と呼び、今回作成した LoRA にはすべて `schematic` という文字を含めています。
+
+| task | output |
+|---|---|
+| relative depth | near = white / far = black |
+| normal map | RGB normal map |
+| pose body | OpenPose 風 body skeleton |
+| pose full | body + hands + face |
+| binary segmentation | visible region mask |
+| amodal segmentation | occluded parts を含む mask |
+
+### amodal segmentation
+
+![](https://gyazo.com/a0cf18a91c6349d3d3002fe98453b723){gyazo=image}
+
+この中で、amodal segmentation というタスクには聞き覚えのない方がいるかもしれません。
+
+- 通常の segmentation は、対象の **見えている領域** だけをマスクします。
+- amodal segmentation は、遮蔽物で隠れている部分も含め、対象全体の形を推定してマスクします。
+
+たとえば鹿の手前を枝が遮っている場合、通常の segmentation では枝の後ろに隠れた部分は出力されません。  
+一方で amodal segmentation では、枝で隠れた部分も含め、鹿全体をマスクとして出力します。
+
+見えない部分を推定する必要があるため、これは単なる分類というより、生成に近いタスクです。  
+逆にいえば、画像生成モデルが力を発揮しやすいタスクでもあるため、今回チャレンジしてみました。
+
+
+### タスク別 LoRA 学習
+
+当初はすべてのタスクをひとつの LoRA として学習させる予定でしたが、内部でタスクが混ざってしまい、プロンプトだけではうまく切り替えられませんでした。
+
+そのため、今回は 1タスク 1LoRA の構成にしています。
+
+---
+
+## データセット
+
+| task | positive | negative | total |
+|---|---:|---:|---:|
+| depth | 300 | 0 | 300 |
+| normal | 300 | 0 | 300 |
+| pose body | 300 | 30 | 330 |
+| pose full | 300 | 30 | 330 |
+| binary segmentation | 300 | 30 | 330 |
+| amodal segmentation | 300 | 30 | 330 |
+
+
+### Depth / Normal
+
+Open Images から画像を取得し、Lotus-2 で teacher を作成。
+
+- depth
+  - relative depth
+  - near = white
+  - far = black
+- normal
+  - RGB normal map
+
+depth と normal は同じ入力画像セットを使っています。
+
+
+### Pose
+
+人物画像を Open Images から取得し、DWPose で teacher を作成。
+
+- pose body
+- pose full
+
+候補画像は目視レビューし、群衆や出力が明らかに崩れているものは除外しています。
+
+
+### Amodal Segmentation
+
+amodal segmentation は、対象物の見えている部分だけでなく、隠れている部分も含めて mask を作るタスクです。
+
+既存データセット、およびこれを直接生成する teacher が手元になかったため、画像生成と画像編集を組み合わせて作成しました。
+
+作成手順:
+
+1. 明確な subject と、それを自然に隠す occluder が含まれる occlusion scene のプロンプトを GPT-5.5 で作成
+2. Z-Image-Turbo で source image を生成
+3. GPT-5.5 が source image を確認
+4. FLUX.2 [klein] 9B image edit で occluder を除去
+5. 除去後画像から target object を SAM 3.1 で segmentation
+6. source image と complete-object mask をペア化
+7. 目視によるレビュー
+8. BiRefNet、および手動でのリファイン
+
+mask は SAM 3.1 だけでは不安定だったため、ほとんどすべてを BiRefNet と手作業で修正しています。
+
+本筋ではないですが、LLM に画像生成プロンプトを大量生成させると、
+
+- 同じような対象物
+- 同じような occluder
+- 同じような構図
+
+に寄ります。そのため、Open Images のランダム画像を inspiration として見せ、scene variation を増やしています。
+
+
+### Binary Segmentation
+
+amodal segmentation 用の source image を流用。
+
+入力画像上で実際に見えている target object の領域を SAM 3.1 で segmentation し、手動でリファインしています。
+
+
+### Negative Samples
+
+pose / segmentation ともに、入力画像に対象が存在しない場合のハルシネーションが問題になります。
+
+例えば、入力画像に猫がいないにもかかわらず `generate mask of the cat` のような指示を与えると、モデルが適当に猫の形のマスクを作ってしまうことがあります。
+
+これに対処するため、all-black target の negative pair を一部追加しました。
+
+- segmentation
+  - 画像に存在しない target を指定した場合、all-black mask を返す
+  - 例: cond 画像にキリンしか写っていない状態で、`cat` の amodal mask を要求する
+- pose
+  - 人物が写っていない入力画像では、all-black pose image を返す
+
+ただし、今回の規模では明確な改善は確認できませんでした。特に pose では、むしろ学習を不安定にした可能性があります。
+
+---
+
+## 学習
+
+[AI-Toolkit](https://github.com/ostris/ai-toolkit) で学習。
+
+| item | value |
+|---|---|
+| base model | `black-forest-labs/FLUX.2-klein-base-9B` |
+| architecture | `flux2_klein_9b` |
+| LoRA rank | linear 32 / conv 16 |
+| optimizer | `adamw8bit` |
+| lr | `5e-5` |
+| dtype | `bf16` |
+| quantization | transformer / text encoder: `qfloat8` |
+| batch size | 4 |
+| text encoder | frozen |
+| caption dropout | 0.05 |
+| EMA | enabled |
+
+解像度は、計算量を抑えるため基本的に 768 bucket を使用。
+
+pose full のみ、顔や手の細部が重要になるため、768 / 1024 bucket を含めて学習しています。
+
+100 step ごとに checkpoint を保存。  
+ComfyUI で実際に動かして、良さそうな step を選びます。すべての LoRA で 2000〜2500 step ほどで収束しています。
+
+---
+
+## workflow
+
+以下は、ComfyUI で使用するための workflow です。
+
+注意として、FLUX.2 [klein] Base で学習した LoRA は、FLUX.2 [klein] Distilled モデルでは上手く動きません。Base モデルを使うか、Distilled と Base の差分 LoRA（[Klein 4B/9B Base to Turbo Lora](https://civitai.com/models/2324315/klein-4b9b-base-to-turbo-lora?modelVersionId=2617121)）を使用してください。
+
+### モデルのダウンロード
+
+ベースは [FLUX.2 [klein]](/ja/basic-workflows/flux-2-klein/) です。
+
+- LoRA
+  - [flux2-klein-schematic-relative-depth-lora.safetensors](https://huggingface.co/nomadoor/flux-2-klein-9B-schematic-lora/blob/main/loras/flux2-klein-schematic-relative-depth-lora.safetensors)
+  - [flux2-klein-schematic-surface-normal-lora.safetensors](https://huggingface.co/nomadoor/flux-2-klein-9B-schematic-lora/blob/main/loras/flux2-klein-schematic-surface-normal-lora.safetensors)
+  - [flux2-klein-schematic-body-pose-lora.safetensors](https://huggingface.co/nomadoor/flux-2-klein-9B-schematic-lora/blob/main/loras/flux2-klein-schematic-body-pose-lora.safetensors)
+  - [flux2-klein-schematic-full-pose-lora.safetensors](https://huggingface.co/nomadoor/flux-2-klein-9B-schematic-lora/blob/main/loras/flux2-klein-schematic-full-pose-lora.safetensors)
+  - [flux2-klein-schematic-binary-segmentation-lora.safetensors](https://huggingface.co/nomadoor/flux-2-klein-9B-schematic-lora/blob/main/loras/flux2-klein-schematic-binary-segmentation-lora.safetensors)
+  - [flux2-klein-schematic-amodal-segmentation-lora.safetensors](https://huggingface.co/nomadoor/flux-2-klein-9B-schematic-lora/blob/main/loras/flux2-klein-schematic-amodal-segmentation-lora.safetensors)
+
+```
+📂ComfyUI/
+└── 📂models/
+    └── 📂loras/
+        ├── flux2-klein-schematic-relative-depth-lora.safetensors
+        ├── flux2-klein-schematic-surface-normal-lora.safetensors
+        ├── flux2-klein-schematic-body-pose-lora.safetensors
+        ├── flux2-klein-schematic-full-pose-lora.safetensors
+        ├── flux2-klein-schematic-binary-segmentation-lora.safetensors
+        └── flux2-klein-schematic-amodal-segmentation-lora.safetensors
+```
+
+### image edit Base
+
+![](https://gyazo.com/596669219726f35c5106037b4fce9e38){gyazo=image}
+
+[](/workflows/notes/flux2-klein-schematic-lora/Flux.2-klein-base-9b_image-edit.json)
+
+---
+
+## 実践テスト
+
+### relative depth
+
+```text
+Generate a relative depth map of the input image.
+```
+
+| input | Depth Anything V2 | FLUX.2 [klein] LoRA |
+|---|---|---|
+| ![](https://gyazo.com/668960b4d9147ef1260a01957f93ce9a){gyazo=image} | ![](https://gyazo.com/20a4dcedf04be910c3dbf0830a34cd02){gyazo=image} | ![](https://gyazo.com/8d011d8f92dfaea759907a6430493d63){gyazo=image} |
+| ![](https://gyazo.com/206992247684d3cc8540037dffe4b088){gyazo=image} | ![](https://gyazo.com/1b39fbf77eb003a1aa38ce800728eb58){gyazo=image} | ![](https://gyazo.com/6e27345a2ecf071e40671ca000fd84f9){gyazo=image} |
+| ![](https://gyazo.com/0ec98b233b467a27a1ac497d2ccf02f9){gyazo=image} | ![](https://gyazo.com/7b1501385098f7cc43354a257739a069){gyazo=image} | ![](https://gyazo.com/ef6402a1b2562118d88f6c471e00bbc0){gyazo=image} |
+
+### normal map
+
+```text
+Generate a surface normal map of the input image.
+```
+
+| input | Lotus-2 | FLUX.2 [klein] LoRA |
+|---|---|---|
+| ![](https://gyazo.com/b3a1684aefa305aacdc41d92ea4c3485){gyazo=image} | ![](https://gyazo.com/a75bc8fdb2794f16d264f8da33dcd7cc){gyazo=image} | ![](https://gyazo.com/a1def11da46b031feabe3f0e6b3f50a2){gyazo=image} |
+| ![](https://gyazo.com/225d29e4318a97b1bfc378091cd06b0e){gyazo=image} | ![](https://gyazo.com/8cc65f987cd5dc9f277efbb242bc6a11){gyazo=image} | ![](https://gyazo.com/595aff620129e00f348fe4ebed8425c7){gyazo=image} |
+| ![](https://gyazo.com/a3566d450ba6209c256f8c55293a428c){gyazo=image} | ![](https://gyazo.com/c2aa1322ad6e17b2b900762ac63f1ba8){gyazo=image} | ![](https://gyazo.com/9f1ea3ff029395ab2d6121c059a3bc3a){gyazo=image} |
+
+### pose body
+
+```text
+Generate a body pose map of all visible people in the input image.
+```
+
+| input | DWPose | FLUX.2 [klein] LoRA |
+|---|---|---|
+| ![](https://gyazo.com/c3e372e31e394aec307a20fbb9b5fb73){gyazo=image} | ![](https://gyazo.com/5aa247ce618c608d195328483bd5f336){gyazo=image} | ![](https://gyazo.com/d503b1b89f9361c12d110e95dba909f0){gyazo=image} |
+| ![](https://gyazo.com/9ee77ec890a84129011b3ef339576171){gyazo=image} | ![](https://gyazo.com/a4a31c41ec507aa59eb0430b0eb05fc3){gyazo=image} | ![](https://gyazo.com/b06ce32e1e60019e84844b5c885f0022){gyazo=image} |
+| ![](https://gyazo.com/bd3bb102f39717b6bbfdae0cc68e96b5){gyazo=image} | ![](https://gyazo.com/5f949073e42723d6bef17932c8aa6139){gyazo=image} | ![](https://gyazo.com/5fcc24d235f0360e1284f32cf30fa9ff){gyazo=image} |
+
+### pose full
+
+```text
+Generate a full pose map of all visible people in the input image.
+```
+
+| input | DWPose | FLUX.2 [klein] LoRA |
+|---|---|---|
+| ![](https://gyazo.com/c3e372e31e394aec307a20fbb9b5fb73){gyazo=image} | ![](https://gyazo.com/cd1c92e205f413cc144b2ec534a398d3){gyazo=image} | ![](https://gyazo.com/aec346f0e8592e8f946f8c2993491955){gyazo=image} |
+| ![](https://gyazo.com/9ee77ec890a84129011b3ef339576171){gyazo=image} | ![](https://gyazo.com/90e9d09c619cbea9c8e788e7b4643616){gyazo=image} | ![](https://gyazo.com/ce5459cca85c4ec415e402d6ecf9da8f){gyazo=image} |
+| ![](https://gyazo.com/bd3bb102f39717b6bbfdae0cc68e96b5){gyazo=image} | ![](https://gyazo.com/5f949073e42723d6bef17932c8aa6139){gyazo=image} | ![](https://gyazo.com/db7abedc5ea7431d831076ce4f58353c){gyazo=image} |
+
+### binary segmentation
+
+```text
+Generate a binary segmentation mask of the stretcher in the input image.
+Generate a binary segmentation mask of the tuna sushi in the input image.
+Generate a binary segmentation mask of all jars in the input image.
+```
+
+| input | SAM 3.1 | FLUX.2 [klein] LoRA |
+|---|---|---|
+| ![](https://gyazo.com/38dd24bd0eec756210f300aa6bc22dbd){gyazo=image} | ![](https://gyazo.com/78f513b8690050f8085995e79a2bf16a){gyazo=image} | ![](https://gyazo.com/8a1faf3881821b454265ab60f7d97af0){gyazo=image} |
+| ![](https://gyazo.com/ff1760a3c6943a2e4e666ec61e1b6eab){gyazo=image} | ![](https://gyazo.com/1abbfc37a68d8335a7f66b9bed7561c3){gyazo=image} | ![](https://gyazo.com/f2ecfb80e270561e7685dfa227855c84){gyazo=image} |
+| ![](https://gyazo.com/5cc009a2cf9ed0da1a2ba74c12e1ec8c){gyazo=image} | ![](https://gyazo.com/a355a426888bd07b48efdf8ee3b6f7d7){gyazo=image} | ![](https://gyazo.com/61c49e77830d9ea82039b839cb18b38e){gyazo=image} |
+
+### amodal segmentation
+
+```text
+Generate an amodal segmentation mask of the woman in the input image.
+Generate an amodal segmentation mask of the bench in the input image.
+Generate an amodal segmentation mask of the steam locomotive in the input image.
+```
+
+| input | SAM 3.1 visible mask | FLUX.2 [klein] LoRA |
+|---|---|---|
+| ![](https://gyazo.com/6b4da57f9c240ace62c66fe6c49c49f6){gyazo=image} | ![](https://gyazo.com/ab3b4dbd6acadbe89e038d121ba011c7){gyazo=image} | ![](https://gyazo.com/79f8e50117e8bbab8dcdfee43b5d75e3){gyazo=image} |
+| ![](https://gyazo.com/3882219095ebaa6a3c148be2cd6c8cbc){gyazo=image} | ![](https://gyazo.com/34b8014d2efe1557b06403772c5c009d){gyazo=image} | ![](https://gyazo.com/fc9840c4f47858a7d52351694494c6c0){gyazo=image} |
+| ![](https://gyazo.com/4a50a286d8870c218e6c792138983ff1){gyazo=image} | ![](https://gyazo.com/95c93284e620212e59cbf261b29f21eb){gyazo=image} | ![](https://gyazo.com/4a3159526479a1ac84b9ce1bc99262d7){gyazo=image} |
+
+---
+
+## 限界と課題
+
+### Depth/Normal
+
+teacher には Lotus-2 を使いましたが、Lotus-2 由来のノイズもそのまま学習してしまいます。
+
+この手のタスクではよく行われるように、3D モデルを使った合成データも検討するべきでした。
+
+余談ですが、Lotus-2 の前に DSINE で作った target 画像でも学習しました。DSINE は Lotus-2 に比べるとかなりのっぺりした Normal map を作成します。その結果、LoRA の出力も同じようにのっぺりしたものになりました。
+
+teacher の質がそのまま LoRA の出力に出るため、データセット品質の重要性を改めて感じます。
+
+### pose
+
+そもそもの問題として、pose は今回のタスクの中ではもっとも RGB 画像での表現に向いていません。
+
+OpenPose 風の画像として出力できても、そこから keypoint へ戻すのは簡単ではなく、実用上の扱いも難しくなります。また、色やボーン数が厳密に決まっているため、少しのブレでもかなり目立ちます。
+
+それでも簡単に学習できるタスクだと思っていましたが、想像以上に崩れました。動物画像や非人物画像でのハルシネーションも防げていません。
+
+### segmentation
+
+テキストエンコーダである Qwen3 8B のプロンプト理解力に期待していましたが、期待ほどのコントロール性能は得られませんでした。
+
+「〇〇の人物を削除して」のような指示には従える一方で、LoRA を適用して「〇〇の人物をセグメンテーションして」と指示すると、失敗したり、別の人物をセグメンテーションしたりします。
+
+そのため、単純なプロンプト理解力だけの問題というより、データセットから segmentation タスクそのものをうまく理解できていない可能性があります。
+
+細部の切り抜き精度についても、本当は matting に近い滑らかな境界を期待していましたが、現状は SAM 3.1 程度の粗さに留まっています。
+
+### 全体
+
+全体として、データセットの枚数が足りていません。
+
+今回、amodal segmentation のデータセット作成が非常に重く、それに合わせて全タスクをおおむね 300 枚で揃えました。  
+ただ、原因をきちんと切り分けるには、各タスク 2000〜3000 枚程度は必要だったように思います。
+
+改善点が多く残っていますが、予算と時間を使いすぎてしまったため、ここで一度断念します。  
+チャンスがあれば、より大きいデータセットで再度試したいですね。
+
+---
+
+## おわりに
+
+品質はさておき、小規模な LoRA 学習だけでも、FLUX.2 [klein] に CV タスク風の RGB 出力をある程度学習させることはできました。
+
+ただし、本質的に重要なのは「CV タスクができたかどうか」ではなく、**何を画像編集として扱うか** によって、画像編集モデルの使い道がまだかなり広がるという点です。
+
+画像編集と聞くと、絵柄変換やオブジェクト除去がすぐに思い浮かびます。  
+しかし、今回のような CV タスク風の出力や、独自の中間表現を作らせることも、広い意味では画像編集として扱えます。
+
+絵を描くだけだった画像生成モデルが、少しずつ汎用的な視覚モデルに近づいていくように見えるのは、楽しいですね。
+
+---
+
+## 参考
+
+- [Marigold: Repurposing Diffusion-Based Image Generators for Monocular Depth Estimation](https://arxiv.org/abs/2312.02145)
+- [Lotus: Diffusion-based Visual Foundation Model for High-quality Dense Prediction](https://huggingface.co/papers/2409.18124)
+- [Lotus-2: Advancing Geometric Dense Prediction with Powerful Image Generative Model](https://huggingface.co/papers/2512.01030)
+- [Vision Banana: Image Generators are Generalist Vision Learners](https://arxiv.org/abs/2604.20329)
+- [Vision Banana Project Page](https://vision-banana.github.io/)

--- a/src/content/ja/notes/flux2-klein-schematic-lora.md
+++ b/src/content/ja/notes/flux2-klein-schematic-lora.md
@@ -205,7 +205,7 @@ ComfyUI で実際に動かして、良さそうな step を選びます。すべ
   - [flux2-klein-schematic-binary-segmentation-lora.safetensors](https://huggingface.co/nomadoor/flux-2-klein-9B-schematic-lora/blob/main/loras/flux2-klein-schematic-binary-segmentation-lora.safetensors)
   - [flux2-klein-schematic-amodal-segmentation-lora.safetensors](https://huggingface.co/nomadoor/flux-2-klein-9B-schematic-lora/blob/main/loras/flux2-klein-schematic-amodal-segmentation-lora.safetensors)
 
-```
+```text
 📂ComfyUI/
 └── 📂models/
     └── 📂loras/

--- a/src/content/zh/news.md
+++ b/src/content/zh/news.md
@@ -5,13 +5,18 @@ slug: news
 navId: news
 title: "更新信息"
 created: 2026-02-05
-updated: 2026-05-29
+updated: 2026-06-01
 summary: "本站的更新信息"
 permalink: "/{{ lang }}/{{ slug }}/"
 tags:
   - news
 ---
 <div class="news-list">
+  <a class="news-row" href="/zh/notes/flux2-klein-schematic-lora/">
+    <span class="news-row__date">2026.6.1</span>
+    <span class="news-row__tag">notes</span>
+    <span class="news-row__title">追加了 FLUX.2 [klein] Schematic LoRA 的页面</span>
+  </a>
   <a class="news-row" href="/zh/basic-workflows/anima/">
     <span class="news-row__date">2026.5.29</span>
     <span class="news-row__tag">basic-workflows</span>

--- a/src/content/zh/notes/flux2-klein-schematic-lora.md
+++ b/src/content/zh/notes/flux2-klein-schematic-lora.md
@@ -1,0 +1,363 @@
+---
+layout: page.njk
+lang: zh
+section: notes
+slug: flux2-klein-schematic-lora
+navId: flux2-klein-schematic-lora
+title: "FLUX.2 [klein] Schematic LoRA"
+created: 2026-05-30
+updated: 2026-06-01
+noteTags: ["project", "flux-2-klein", "lora"]
+summary: "让 FLUX.2 [klein] 学习 CV 任务风格的 RGB 输出"
+permalink: "/{{ lang }}/notes/{{ slug }}/"
+hero:
+  image: "https://i.gyazo.com/a0dc0970df98429dcf703e3ed095f6fa.png"
+---
+
+## 概述
+
+![](https://gyazo.com/2bd9f7b01d61bea0658ba82a750f227e){gyazo=image}
+
+利用图像生成模型的先验知识来做 CV 任务的研究有不少。代表性的例子包括 [Marigold](https://arxiv.org/abs/2312.02145)、[Lotus-2](https://huggingface.co/papers/2512.01030)、[SDPose](https://tsliang.top/SDPose/) 等。
+
+这些方法虽然利用了预训练图像生成模型，但最终仍然是为各自任务专门设计的。
+
+不过，在指令式图像编辑模型已经变得常见的今天，也出现了另一种思路：从图像进行深度估计或分割这类任务，是否也可以在更宽泛的意义上当作 **图像编辑** 来处理？Google DeepMind 的 [Vision Banana](https://vision-banana.github.io/) 就是这样的研究。
+
+受到这个方向的启发，我想试试看 FLUX.2 [klein] 是否也能做类似的事情。
+
+结果当然谈不上达到 SOTA 性能。不过我希望这个实验能说明，仅靠简单的 LoRA 训练，也可以在本地模型上尝试接近 Vision Banana 方向的行为。
+
+---
+
+## 任务设定
+
+Vision Banana 主要处理 depth / normal / segmentation。
+
+这次没有完全照搬它的任务构成，而是选择了 ComfyUI / 图像生成社区里更熟悉的，也就是类似 ControlNet Preprocessor 的输出。
+
+我个人把这些任务称为 `image2schematic`，这次创建的 LoRA 名称里也都包含 `schematic` 这个词。
+
+| task | output |
+|---|---|
+| relative depth | near = white / far = black |
+| normal map | RGB normal map |
+| pose body | OpenPose 风 body skeleton |
+| pose full | body + hands + face |
+| binary segmentation | visible region mask |
+| amodal segmentation | 包含 occluded parts 的 mask |
+
+### amodal segmentation
+
+![](https://gyazo.com/a0cf18a91c6349d3d3002fe98453b723){gyazo=image}
+
+这里面，可能有人没听过 amodal segmentation 这个任务。
+
+- 普通 segmentation 只会 mask 对象 **实际可见的区域**。
+- amodal segmentation 会把遮挡物后面看不见的部分也包含进去，推定对象整体形状并生成 mask。
+
+比如鹿的前面被树枝遮住时，普通 segmentation 不会输出树枝后面被挡住的部分。  
+而 amodal segmentation 会把被树枝挡住的部分也包括进去，输出鹿整体的 mask。
+
+因为需要推定看不见的部分，所以它与其说是单纯分类，不如说更接近生成。  
+反过来说，这也是图像生成模型可能比较能发挥能力的任务，所以这次尝试了一下。
+
+### 按任务分别训练 LoRA
+
+一开始我打算把所有任务训练到一个 LoRA 里，但内部任务混在了一起，单靠 prompt 无法稳定切换。
+
+因此这次采用 1 个任务 1 个 LoRA 的构成。
+
+---
+
+## 数据集
+
+| task | positive | negative | total |
+|---|---:|---:|---:|
+| depth | 300 | 0 | 300 |
+| normal | 300 | 0 | 300 |
+| pose body | 300 | 30 | 330 |
+| pose full | 300 | 30 | 330 |
+| binary segmentation | 300 | 30 | 330 |
+| amodal segmentation | 300 | 30 | 330 |
+
+### Depth / Normal
+
+从 Open Images 获取图像，并用 Lotus-2 创建 teacher。
+
+- depth
+  - relative depth
+  - near = white
+  - far = black
+- normal
+  - RGB normal map
+
+depth 和 normal 使用同一组输入图像。
+
+### Pose
+
+从 Open Images 获取人物图像，并用 DWPose 创建 teacher。
+
+- pose body
+- pose full
+
+候选图像经过目视检查，排除了人群图像以及输出明显崩坏的图像。
+
+### Amodal Segmentation
+
+amodal segmentation 是为对象创建 mask 的任务，不只包含可见部分，也包含被遮挡的部分。
+
+手头没有现成数据集，也没有能直接生成它的 teacher，所以这次结合图像生成和图像编辑来制作。
+
+制作流程：
+
+1. 让 GPT-5.5 创建包含明确 subject 和自然 occluder 的 occlusion scene prompt
+2. 用 Z-Image-Turbo 生成 source image
+3. GPT-5.5 检查 source image
+4. 用 FLUX.2 [klein] 9B image edit 去除 occluder
+5. 从去除后的图像中，用 SAM 3.1 对 target object 做 segmentation
+6. 将 source image 和 complete-object mask 配对
+7. 目视检查
+8. 使用 BiRefNet 以及手动方式修正
+
+mask 只靠 SAM 3.1 并不稳定，所以几乎全部都用 BiRefNet 和手动方式修正过。
+
+这不是主线内容，但如果让 LLM 大量生成图像 prompt，结果会容易偏向：
+
+- 相似的对象
+- 相似的 occluder
+- 相似的构图
+
+因此我把 Open Images 的随机图像作为 inspiration 给它看，用来增加 scene variation。
+
+### Binary Segmentation
+
+复用 amodal segmentation 用的 source image。
+
+对输入图像中实际可见的 target object 区域，用 SAM 3.1 做 segmentation，并手动修正。
+
+### Negative Samples
+
+pose / segmentation 都会遇到一个问题：当输入图像里不存在目标对象时，模型容易 hallucination。
+
+例如，输入图像里没有猫，却给出 `generate mask of the cat` 这样的指令时，模型可能会随便生成一个猫形状的 mask。
+
+为了解决这个问题，我加入了一部分 all-black target 的 negative pair。
+
+- segmentation
+  - 当指定的 target 不存在于图像中时，返回 all-black mask
+  - 例：cond 图像里只有长颈鹿，却要求生成 `cat` 的 amodal mask
+- pose
+  - 输入图像里没有人物时，返回 all-black pose image
+
+不过，以这次的规模来看，没有确认到明确改善。尤其在 pose 上，反而可能让训练变得不稳定。
+
+---
+
+## 训练
+
+使用 [AI Toolkit](https://github.com/ostris/ai-toolkit) 训练。
+
+| item | value |
+|---|---|
+| base model | `black-forest-labs/FLUX.2-klein-base-9B` |
+| architecture | `flux2_klein_9b` |
+| LoRA rank | linear 32 / conv 16 |
+| optimizer | `adamw8bit` |
+| lr | `5e-5` |
+| dtype | `bf16` |
+| quantization | transformer / text encoder: `qfloat8` |
+| batch size | 4 |
+| text encoder | frozen |
+| caption dropout | 0.05 |
+| EMA | enabled |
+
+为了降低计算量，分辨率基本使用 768 bucket。
+
+只有 pose full 因为脸和手的细节更重要，所以加入了 768 / 1024 bucket 来训练。
+
+每 100 step 保存一次 checkpoint。  
+然后在 ComfyUI 中实际运行，选择看起来比较好的 step。所有 LoRA 大约都在 2000～2500 step 左右收敛。
+
+---
+
+## workflow
+
+下面是用于在 ComfyUI 中使用这些 LoRA 的 workflow。
+
+需要注意，基于 FLUX.2 [klein] Base 训练的 LoRA，在 FLUX.2 [klein] Distilled 模型上运行效果不好。请使用 Base 模型，或者使用 Distilled 与 Base 的差分 LoRA（[Klein 4B/9B Base to Turbo Lora](https://civitai.com/models/2324315/klein-4b9b-base-to-turbo-lora?modelVersionId=2617121)）。
+
+### 模型下载
+
+基础模型是 [FLUX.2 [klein]](/zh/basic-workflows/flux-2-klein/)。
+
+- LoRA
+  - [flux2-klein-schematic-relative-depth-lora.safetensors](https://huggingface.co/nomadoor/flux-2-klein-9B-schematic-lora/blob/main/loras/flux2-klein-schematic-relative-depth-lora.safetensors)
+  - [flux2-klein-schematic-surface-normal-lora.safetensors](https://huggingface.co/nomadoor/flux-2-klein-9B-schematic-lora/blob/main/loras/flux2-klein-schematic-surface-normal-lora.safetensors)
+  - [flux2-klein-schematic-body-pose-lora.safetensors](https://huggingface.co/nomadoor/flux-2-klein-9B-schematic-lora/blob/main/loras/flux2-klein-schematic-body-pose-lora.safetensors)
+  - [flux2-klein-schematic-full-pose-lora.safetensors](https://huggingface.co/nomadoor/flux-2-klein-9B-schematic-lora/blob/main/loras/flux2-klein-schematic-full-pose-lora.safetensors)
+  - [flux2-klein-schematic-binary-segmentation-lora.safetensors](https://huggingface.co/nomadoor/flux-2-klein-9B-schematic-lora/blob/main/loras/flux2-klein-schematic-binary-segmentation-lora.safetensors)
+  - [flux2-klein-schematic-amodal-segmentation-lora.safetensors](https://huggingface.co/nomadoor/flux-2-klein-9B-schematic-lora/blob/main/loras/flux2-klein-schematic-amodal-segmentation-lora.safetensors)
+
+```text
+📂ComfyUI/
+└── 📂models/
+    └── 📂loras/
+        ├── flux2-klein-schematic-relative-depth-lora.safetensors
+        ├── flux2-klein-schematic-surface-normal-lora.safetensors
+        ├── flux2-klein-schematic-body-pose-lora.safetensors
+        ├── flux2-klein-schematic-full-pose-lora.safetensors
+        ├── flux2-klein-schematic-binary-segmentation-lora.safetensors
+        └── flux2-klein-schematic-amodal-segmentation-lora.safetensors
+```
+
+### image edit Base
+
+![](https://gyazo.com/596669219726f35c5106037b4fce9e38){gyazo=image}
+
+[](/workflows/notes/flux2-klein-schematic-lora/Flux.2-klein-base-9b_image-edit.json)
+
+---
+
+## 实践测试
+
+### relative depth
+
+```text
+Generate a relative depth map of the input image.
+```
+
+| input | Depth Anything V2 | FLUX.2 [klein] LoRA |
+|---|---|---|
+| ![](https://gyazo.com/668960b4d9147ef1260a01957f93ce9a){gyazo=image} | ![](https://gyazo.com/20a4dcedf04be910c3dbf0830a34cd02){gyazo=image} | ![](https://gyazo.com/8d011d8f92dfaea759907a6430493d63){gyazo=image} |
+| ![](https://gyazo.com/206992247684d3cc8540037dffe4b088){gyazo=image} | ![](https://gyazo.com/1b39fbf77eb003a1aa38ce800728eb58){gyazo=image} | ![](https://gyazo.com/6e27345a2ecf071e40671ca000fd84f9){gyazo=image} |
+| ![](https://gyazo.com/0ec98b233b467a27a1ac497d2ccf02f9){gyazo=image} | ![](https://gyazo.com/7b1501385098f7cc43354a257739a069){gyazo=image} | ![](https://gyazo.com/ef6402a1b2562118d88f6c471e00bbc0){gyazo=image} |
+
+### normal map
+
+```text
+Generate a surface normal map of the input image.
+```
+
+| input | Lotus-2 | FLUX.2 [klein] LoRA |
+|---|---|---|
+| ![](https://gyazo.com/b3a1684aefa305aacdc41d92ea4c3485){gyazo=image} | ![](https://gyazo.com/a75bc8fdb2794f16d264f8da33dcd7cc){gyazo=image} | ![](https://gyazo.com/a1def11da46b031feabe3f0e6b3f50a2){gyazo=image} |
+| ![](https://gyazo.com/225d29e4318a97b1bfc378091cd06b0e){gyazo=image} | ![](https://gyazo.com/8cc65f987cd5dc9f277efbb242bc6a11){gyazo=image} | ![](https://gyazo.com/595aff620129e00f348fe4ebed8425c7){gyazo=image} |
+| ![](https://gyazo.com/a3566d450ba6209c256f8c55293a428c){gyazo=image} | ![](https://gyazo.com/c2aa1322ad6e17b2b900762ac63f1ba8){gyazo=image} | ![](https://gyazo.com/9f1ea3ff029395ab2d6121c059a3bc3a){gyazo=image} |
+
+### pose body
+
+```text
+Generate a body pose map of all visible people in the input image.
+```
+
+| input | DWPose | FLUX.2 [klein] LoRA |
+|---|---|---|
+| ![](https://gyazo.com/c3e372e31e394aec307a20fbb9b5fb73){gyazo=image} | ![](https://gyazo.com/5aa247ce618c608d195328483bd5f336){gyazo=image} | ![](https://gyazo.com/d503b1b89f9361c12d110e95dba909f0){gyazo=image} |
+| ![](https://gyazo.com/9ee77ec890a84129011b3ef339576171){gyazo=image} | ![](https://gyazo.com/a4a31c41ec507aa59eb0430b0eb05fc3){gyazo=image} | ![](https://gyazo.com/b06ce32e1e60019e84844b5c885f0022){gyazo=image} |
+| ![](https://gyazo.com/bd3bb102f39717b6bbfdae0cc68e96b5){gyazo=image} | ![](https://gyazo.com/5f949073e42723d6bef17932c8aa6139){gyazo=image} | ![](https://gyazo.com/5fcc24d235f0360e1284f32cf30fa9ff){gyazo=image} |
+
+### pose full
+
+```text
+Generate a full pose map of all visible people in the input image.
+```
+
+| input | DWPose | FLUX.2 [klein] LoRA |
+|---|---|---|
+| ![](https://gyazo.com/c3e372e31e394aec307a20fbb9b5fb73){gyazo=image} | ![](https://gyazo.com/cd1c92e205f413cc144b2ec534a398d3){gyazo=image} | ![](https://gyazo.com/aec346f0e8592e8f946f8c2993491955){gyazo=image} |
+| ![](https://gyazo.com/9ee77ec890a84129011b3ef339576171){gyazo=image} | ![](https://gyazo.com/90e9d09c619cbea9c8e788e7b4643616){gyazo=image} | ![](https://gyazo.com/ce5459cca85c4ec415e402d6ecf9da8f){gyazo=image} |
+| ![](https://gyazo.com/bd3bb102f39717b6bbfdae0cc68e96b5){gyazo=image} | ![](https://gyazo.com/5f949073e42723d6bef17932c8aa6139){gyazo=image} | ![](https://gyazo.com/db7abedc5ea7431d831076ce4f58353c){gyazo=image} |
+
+### binary segmentation
+
+```text
+Generate a binary segmentation mask of the stretcher in the input image.
+Generate a binary segmentation mask of the tuna sushi in the input image.
+Generate a binary segmentation mask of all jars in the input image.
+```
+
+| input | SAM 3.1 | FLUX.2 [klein] LoRA |
+|---|---|---|
+| ![](https://gyazo.com/38dd24bd0eec756210f300aa6bc22dbd){gyazo=image} | ![](https://gyazo.com/78f513b8690050f8085995e79a2bf16a){gyazo=image} | ![](https://gyazo.com/8a1faf3881821b454265ab60f7d97af0){gyazo=image} |
+| ![](https://gyazo.com/ff1760a3c6943a2e4e666ec61e1b6eab){gyazo=image} | ![](https://gyazo.com/1abbfc37a68d8335a7f66b9bed7561c3){gyazo=image} | ![](https://gyazo.com/f2ecfb80e270561e7685dfa227855c84){gyazo=image} |
+| ![](https://gyazo.com/5cc009a2cf9ed0da1a2ba74c12e1ec8c){gyazo=image} | ![](https://gyazo.com/a355a426888bd07b48efdf8ee3b6f7d7){gyazo=image} | ![](https://gyazo.com/61c49e77830d9ea82039b839cb18b38e){gyazo=image} |
+
+### amodal segmentation
+
+```text
+Generate an amodal segmentation mask of the woman in the input image.
+Generate an amodal segmentation mask of the bench in the input image.
+Generate an amodal segmentation mask of the steam locomotive in the input image.
+```
+
+| input | SAM 3.1 visible mask | FLUX.2 [klein] LoRA |
+|---|---|---|
+| ![](https://gyazo.com/6b4da57f9c240ace62c66fe6c49c49f6){gyazo=image} | ![](https://gyazo.com/ab3b4dbd6acadbe89e038d121ba011c7){gyazo=image} | ![](https://gyazo.com/79f8e50117e8bbab8dcdfee43b5d75e3){gyazo=image} |
+| ![](https://gyazo.com/3882219095ebaa6a3c148be2cd6c8cbc){gyazo=image} | ![](https://gyazo.com/34b8014d2efe1557b06403772c5c009d){gyazo=image} | ![](https://gyazo.com/fc9840c4f47858a7d52351694494c6c0){gyazo=image} |
+| ![](https://gyazo.com/4a50a286d8870c218e6c792138983ff1){gyazo=image} | ![](https://gyazo.com/95c93284e620212e59cbf261b29f21eb){gyazo=image} | ![](https://gyazo.com/4a3159526479a1ac84b9ce1bc99262d7){gyazo=image} |
+
+---
+
+## 局限与问题
+
+### Depth / Normal
+
+teacher 使用的是 Lotus-2，但 Lotus-2 自身带来的噪声也会被 LoRA 一起学进去。
+
+对于这类任务，本来应该也考虑使用 3D 模型生成的合成数据。
+
+顺便一提，在使用 Lotus-2 之前，我也用 DSINE 创建的 target 图像训练过。DSINE 生成的 Normal map 比 Lotus-2 平很多，结果 LoRA 的输出也同样变得很平。
+
+teacher 的质量会直接反映到 LoRA 的输出上，这让我再次感受到数据集质量的重要性。
+
+### pose
+
+首先，pose 是这次任务中最不适合用 RGB 图像表达的任务。
+
+即使能输出 OpenPose 风格图像，把它再转换回 keypoint 也并不容易，实际使用上会比较麻烦。另外，颜色和骨骼数量都有严格规则，所以一点点偏差也会很显眼。
+
+我原本以为这是一个容易训练的任务，但实际比想象中更容易崩。动物图像和非人物图像上的 hallucination 也没有防住。
+
+### segmentation
+
+我原本期待文本编码器 Qwen3 8B 的 prompt 理解力能发挥作用，但控制能力没有达到预期。
+
+它可以听懂“删除某某人物”这样的指令，但在应用 LoRA 后要求“segment 某某人物”时，会失败，或者 segment 到另一个人物。
+
+因此，这可能不只是 prompt 理解力的问题。模型也可能没有从数据集中很好地理解 segmentation 任务本身。
+
+细节抠图精度方面，我本来期待能接近 matting 那种更平滑的边界，但目前还停留在 SAM 3.1 左右的粗糙程度。
+
+### 整体
+
+整体来看，数据集数量不够。
+
+这次 amodal segmentation 的数据集制作非常重，所以为了统一规模，所有任务大致都控制在 300 张左右。  
+不过如果要认真切分原因，我觉得每个任务大概需要 2000～3000 张。
+
+还有很多改进点，但预算和时间已经花得太多，所以这次先到这里。  
+如果有机会，希望能用更大的数据集再试一次。
+
+---
+
+## 结语
+
+先不谈质量如何，仅靠小规模 LoRA 训练，也确实能让 FLUX.2 [klein] 在一定程度上学会 CV 任务风格的 RGB 输出。
+
+不过真正重要的，并不是“是否完成了 CV 任务”，而是根据 **我们把什么东西当作图像编辑来处理**，图像编辑模型的用途还可以继续扩展。
+
+一提到图像编辑，最先想到的通常是画风转换或对象移除。  
+但像这次这种 CV 任务风格输出，或者让模型生成自定义中间表示，也可以在广义上当作图像编辑。
+
+原本只是“画图”的图像生成模型，逐渐变得像通用视觉模型一样，这一点很有趣。
+
+---
+
+## 参考
+
+- [Marigold: Repurposing Diffusion-Based Image Generators for Monocular Depth Estimation](https://arxiv.org/abs/2312.02145)
+- [Lotus: Diffusion-based Visual Foundation Model for High-quality Dense Prediction](https://huggingface.co/papers/2409.18124)
+- [Lotus-2: Advancing Geometric Dense Prediction with Powerful Image Generative Model](https://huggingface.co/papers/2512.01030)
+- [Vision Banana: Image Generators are Generalist Vision Learners](https://arxiv.org/abs/2604.20329)
+- [Vision Banana Project Page](https://vision-banana.github.io/)

--- a/src/workflows/notes/flux2-klein-schematic-lora/Flux.2-klein-base-9b_image-edit.json
+++ b/src/workflows/notes/flux2-klein-schematic-lora/Flux.2-klein-base-9b_image-edit.json
@@ -1,0 +1,848 @@
+{
+  "id": "37b279c2-46a8-4e38-ae9d-efce5a7f30a1",
+  "revision": 0,
+  "last_node_id": 90,
+  "last_link_id": 204,
+  "nodes": [
+    {
+      "id": 49,
+      "type": "ReferenceLatent",
+      "pos": [
+        1021.3615651604734,
+        160.40068341159756
+      ],
+      "size": [
+        204.134765625,
+        46
+      ],
+      "flags": {},
+      "order": 12,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "conditioning",
+          "type": "CONDITIONING",
+          "link": 70
+        },
+        {
+          "name": "latent",
+          "shape": 7,
+          "type": "LATENT",
+          "link": 75
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            71
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.9.2",
+        "Node name for S&R": "ReferenceLatent"
+      },
+      "widgets_values": [],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 52,
+      "type": "VAEEncode",
+      "pos": [
+        821.9650317382822,
+        579.5488468801722
+      ],
+      "size": [
+        162,
+        46
+      ],
+      "flags": {},
+      "order": 11,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "pixels",
+          "type": "IMAGE",
+          "link": 149
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 76
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            74,
+            75,
+            84
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.9.2",
+        "Node name for S&R": "VAEEncode"
+      },
+      "widgets_values": [],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 55,
+      "type": "ReferenceLatent",
+      "pos": [
+        1021.3615651604734,
+        387.24938745307793
+      ],
+      "size": [
+        204.134765625,
+        46
+      ],
+      "flags": {},
+      "order": 13,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "conditioning",
+          "type": "CONDITIONING",
+          "link": 83
+        },
+        {
+          "name": "latent",
+          "shape": 7,
+          "type": "LATENT",
+          "link": 84
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            85
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.9.2",
+        "Node name for S&R": "ReferenceLatent"
+      },
+      "widgets_values": [],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 44,
+      "type": "CLIPLoader",
+      "pos": [
+        224.49879211425772,
+        292.66704483032197
+      ],
+      "size": [
+        283.80000000000007,
+        106
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [
+            63,
+            64
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.73",
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": [
+        "qwen_3_8b.safetensors",
+        "flux2",
+        "default"
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 43,
+      "type": "VAELoader",
+      "pos": [
+        520.2735954205992,
+        751.5950256347664
+      ],
+      "size": [
+        269.8313103058076,
+        58
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [
+            62,
+            76
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.39",
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": [
+        "flux2-vae.safetensors"
+      ],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 51,
+      "type": "ResizeImageMaskNode",
+      "pos": [
+        213.01819139432666,
+        579.5488468801722
+      ],
+      "size": [
+        270,
+        106
+      ],
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input",
+          "type": "IMAGE,MASK",
+          "link": 196
+        }
+      ],
+      "outputs": [
+        {
+          "name": "resized",
+          "type": "IMAGE",
+          "links": [
+            82
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.9.2",
+        "Node name for S&R": "ResizeImageMaskNode"
+      },
+      "widgets_values": [
+        "scale total pixels",
+        1,
+        "nearest-exact"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 33,
+      "type": "CLIPTextEncode",
+      "pos": [
+        558.700000000001,
+        387.24938745307793
+      ],
+      "size": [
+        425.2650317382812,
+        122.99611236572264
+      ],
+      "flags": {
+        "collapsed": false
+      },
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 64
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            83
+          ]
+        }
+      ],
+      "title": "CLIP Text Encode (Negative Prompt)",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.39",
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "text, worst quality, blurry, ugly"
+      ]
+    },
+    {
+      "id": 48,
+      "type": "UNETLoader",
+      "pos": [
+        500.7576387664047,
+        0.22617585350672265
+      ],
+      "size": [
+        308.1592787377913,
+        82
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            140
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.9.2",
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": [
+        "Flux.2/flux-2-klein-base-9b-fp8.safetensors",
+        "default"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 45,
+      "type": "SaveImage",
+      "pos": [
+        1827.035886825295,
+        160.40068341159756
+      ],
+      "size": [
+        672.8774941199636,
+        835.2894627396925
+      ],
+      "flags": {},
+      "order": 16,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 65
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.73"
+      },
+      "widgets_values": [
+        "ComfyUI"
+      ]
+    },
+    {
+      "id": 8,
+      "type": "VAEDecode",
+      "pos": [
+        1615.039087801503,
+        160.40068341159756
+      ],
+      "size": [
+        161.111083984375,
+        46
+      ],
+      "flags": {},
+      "order": 15,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 52
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 62
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [
+            65
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.39",
+        "Node name for S&R": "VAEDecode"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 54,
+      "type": "ResizeImageMaskNode",
+      "pos": [
+        517.4916115663044,
+        579.5488468801722
+      ],
+      "size": [
+        270,
+        106
+      ],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input",
+          "type": "IMAGE,MASK",
+          "link": 82
+        }
+      ],
+      "outputs": [
+        {
+          "name": "resized",
+          "type": "IMAGE",
+          "links": [
+            149
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.9.2",
+        "Node name for S&R": "ResizeImageMaskNode"
+      },
+      "widgets_values": [
+        "scale to multiple",
+        16,
+        "nearest-exact"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 50,
+      "type": "LoadImage",
+      "pos": [
+        -139.92346878942647,
+        579.5488468801722
+      ],
+      "size": [
+        324.77206892429183,
+        437.2170640540477
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            196
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.9.2",
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": [
+        "000144_00001_.png",
+        "image"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 84,
+      "type": "MarkdownNote",
+      "pos": [
+        12.952843572078905,
+        -258.08006758864195
+      ],
+      "size": [
+        425.4143199001238,
+        450.1487253162147
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "# Workflow Prompts\n\n## Relative Depth\n\n```text\nGenerate a relative depth map of the input image.\n```\n\n## Surface Normal\n\n```text\nGenerate a surface normal map of the input image.\n```\n\n## Body Pose\n\n```text\nGenerate a body pose map of all visible people in the input image.\n```\n\n## Full Pose\n\n```text\nGenerate a full pose map of all visible people in the input image.\n```\n\n## Binary Segmentation\n\n```text\nGenerate a binary segmentation mask of [target] in the input image.\n```\n\n## Amodal Segmentation\n\n```text\nGenerate an amodal segmentation mask of [target] in the input image.\n```"
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 6,
+      "type": "CLIPTextEncode",
+      "pos": [
+        558.700000000001,
+        160.40068341159756
+      ],
+      "size": [
+        425.2650317382812,
+        167.9430462646484
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 63
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            70
+          ]
+        }
+      ],
+      "title": "CLIP Text Encode (Positive Prompt)",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.39",
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "Generate a relative depth map of the input image.\n"
+      ]
+    },
+    {
+      "id": 31,
+      "type": "KSampler",
+      "pos": [
+        1262.7259909887628,
+        160.40068341159756
+      ],
+      "size": [
+        315,
+        262
+      ],
+      "flags": {},
+      "order": 14,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 193
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 71
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 85
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 74
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "slot_index": 0,
+          "links": [
+            52
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.39",
+        "Node name for S&R": "KSampler"
+      },
+      "widgets_values": [
+        1234,
+        "fixed",
+        20,
+        5,
+        "euler",
+        "simple",
+        1
+      ]
+    },
+    {
+      "id": 81,
+      "type": "LoraLoaderModelOnly",
+      "pos": [
+        834.1673366934359,
+        0.22617585350672265
+      ],
+      "size": [
+        393.62824686843055,
+        82
+      ],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 140
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            193
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.20.1",
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": [
+        "flux2-klein-schematic-relative-depth-lora.safetensors",
+        0.8
+      ]
+    },
+    {
+      "id": 85,
+      "type": "MarkdownNote",
+      "pos": [
+        -458.2999499066289,
+        -259.54092129190855
+      ],
+      "size": [
+        423.753902071114,
+        543.7932327033926
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "## models\n\n* diffusion_models\n\n  * [flux-2-klein-base-9b-fp8.safetensors](https://huggingface.co/black-forest-labs/FLUX.2-klein-base-9b-fp8/blob/main/flux-2-klein-base-9b-fp8.safetensors)\n* text_encoders\n\n  * [qwen_3_8b.safetensors](https://huggingface.co/Comfy-Org/vae-text-encorder-for-flux-klein-9b/blob/main/split_files/text_encoders/qwen_3_8b.safetensors)\n* vae\n\n  * [flux2-vae.safetensors](https://huggingface.co/Comfy-Org/vae-text-encorder-for-flux-klein-9b/blob/main/split_files/vae/flux2-vae.safetensors)\n\n\n```text\n📂ComfyUI/\n└── 📂models/\n    ├── 📂diffusion_models/\n    │   ├── flux-2-klein-9b-fp8.safetensors\n    │   └── flux-2-klein-base-9b-fp8.safetensors\n    ├── 📂text_encoders/\n    │   └── qwen_3_8b.safetensors\n    └── 📂vae/\n         └── flux2-vae.safetensors\n```\n\n### loras\n\n- loras\n  - [flux2-klein-schematic-relative-depth-lora.safetensors](https://huggingface.co/nomadoor/flux-2-klein-9B-schematic-lora/blob/main/loras/flux2-klein-schematic-relative-depth-lora.safetensors)\n  - [flux2-klein-schematic-surface-normal-lora.safetensors](https://huggingface.co/nomadoor/flux-2-klein-9B-schematic-lora/blob/main/loras/flux2-klein-schematic-surface-normal-lora.safetensors)\n  - [flux2-klein-schematic-body-pose-lora.safetensors](https://huggingface.co/nomadoor/flux-2-klein-9B-schematic-lora/blob/main/loras/flux2-klein-schematic-body-pose-lora.safetensors)\n  - [flux2-klein-schematic-full-pose-lora.safetensors](https://huggingface.co/nomadoor/flux-2-klein-9B-schematic-lora/blob/main/loras/flux2-klein-schematic-full-pose-lora.safetensors)\n  - [flux2-klein-schematic-binary-segmentation-lora.safetensors](https://huggingface.co/nomadoor/flux-2-klein-9B-schematic-lora/blob/main/loras/flux2-klein-schematic-binary-segmentation-lora.safetensors)\n  - [flux2-klein-schematic-amodal-segmentation-lora.safetensors](https://huggingface.co/nomadoor/flux-2-klein-9B-schematic-lora/blob/main/loras/flux2-klein-schematic-amodal-segmentation-lora.safetensors)\n\n```\n📂ComfyUI/\n└── 📂models/\n    └── 📂loras/\n        ├── flux2-klein-schematic-relative-depth-lora.safetensors\n        ├── flux2-klein-schematic-surface-normal-lora.safetensors\n        ├── flux2-klein-schematic-body-pose-lora.safetensors\n        ├── flux2-klein-schematic-full-pose-lora.safetensors\n        ├── flux2-klein-schematic-binary-segmentation-lora.safetensors\n        └── flux2-klein-schematic-amodal-segmentation-lora.safetensors\n```"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    }
+  ],
+  "links": [
+    [
+      52,
+      31,
+      0,
+      8,
+      0,
+      "LATENT"
+    ],
+    [
+      62,
+      43,
+      0,
+      8,
+      1,
+      "VAE"
+    ],
+    [
+      63,
+      44,
+      0,
+      6,
+      0,
+      "CLIP"
+    ],
+    [
+      64,
+      44,
+      0,
+      33,
+      0,
+      "CLIP"
+    ],
+    [
+      65,
+      8,
+      0,
+      45,
+      0,
+      "IMAGE"
+    ],
+    [
+      70,
+      6,
+      0,
+      49,
+      0,
+      "CONDITIONING"
+    ],
+    [
+      71,
+      49,
+      0,
+      31,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      74,
+      52,
+      0,
+      31,
+      3,
+      "LATENT"
+    ],
+    [
+      75,
+      52,
+      0,
+      49,
+      1,
+      "LATENT"
+    ],
+    [
+      76,
+      43,
+      0,
+      52,
+      1,
+      "VAE"
+    ],
+    [
+      82,
+      51,
+      0,
+      54,
+      0,
+      "IMAGE"
+    ],
+    [
+      83,
+      33,
+      0,
+      55,
+      0,
+      "CONDITIONING"
+    ],
+    [
+      84,
+      52,
+      0,
+      55,
+      1,
+      "LATENT"
+    ],
+    [
+      85,
+      55,
+      0,
+      31,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      140,
+      48,
+      0,
+      81,
+      0,
+      "MODEL"
+    ],
+    [
+      149,
+      54,
+      0,
+      52,
+      0,
+      "IMAGE"
+    ],
+    [
+      193,
+      81,
+      0,
+      31,
+      0,
+      "MODEL"
+    ],
+    [
+      196,
+      50,
+      0,
+      51,
+      0,
+      "IMAGE"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.7627768444385989,
+      "offset": [
+        1370.6596805987829,
+        510.4137858114659
+      ]
+    },
+    "frontendVersion": "1.42.15",
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true
+  },
+  "version": 0.4
+}


### PR DESCRIPTION
## Summary
- Add the FLUX.2 [klein] Schematic LoRA note in Japanese, English, and Chinese.
- Add the shared ComfyUI workflow JSON and news entries for all three languages.
- Document and implement compact image-comparison table sizing for article media.

## Checks
- git diff --check
- python3 -m json.tool src/workflows/notes/flux2-klein-schematic-lora/Flux.2-klein-base-9b_image-edit.json
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive FLUX.2 [klein] Schematic LoRA guide covering task definitions, dataset construction, training configuration, and practical test results in English, Japanese, and Chinese.
  * Added new experiment note for FLUX.2 Klein Schematic LoRA.
  * Added ComfyUI workflow for image editing with Flux.2 klein base model.

* **Style**
  * Enhanced image comparison table layout and styling for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->