### PR TITLE
Update FLUX.2 schematic LoRA note references

### DIFF
--- a/src/content/en/notes/flux2-klein-schematic-lora.md
+++ b/src/content/en/notes/flux2-klein-schematic-lora.md
@@ -18,7 +18,7 @@ hero:
 
 ![](https://gyazo.com/2bd9f7b01d61bea0658ba82a750f227e){gyazo=image}
 
-There are many studies that reuse the prior knowledge of image generation models for CV tasks. Representative examples include [Marigold](https://arxiv.org/abs/2312.02145), [Lotus-2](https://huggingface.co/papers/2512.01030), and [SDPose](https://tsliang.top/SDPose/).
+There are many studies that reuse the prior knowledge of image generation models for CV tasks. Representative examples include [Marigold](https://marigoldmonodepth.github.io/), [Lotus-2](https://huggingface.co/papers/2512.01030), and [SDPose](https://tsliang.top/SDPose/).
 
 Although these methods use pretrained image generation models, they are ultimately designed specifically for each task.
 
@@ -115,6 +115,8 @@ Amodal segmentation is a task that creates a mask for the whole object, includin
 I did not have an existing dataset or a teacher that could directly generate this, so I created it by combining image generation and image editing.
 
 Creation flow:
+
+![](https://gyazo.com/c3daf3c0a5804bf37d4920a95c7dde61){gyazo=image}
 
 1. GPT-5.5 created prompts for occlusion scenes with a clear subject and a natural occluder
 2. Z-Image-Turbo generated the source image

--- a/src/content/ja/notes/flux2-klein-schematic-lora.md
+++ b/src/content/ja/notes/flux2-klein-schematic-lora.md
@@ -18,7 +18,7 @@ hero:
 
 ![](https://gyazo.com/2bd9f7b01d61bea0658ba82a750f227e){gyazo=image}
 
-画像生成モデルの事前知識を活用して、CV タスクに応用する研究はいくつもあります。代表的なものでいえば、[Marigold](https://arxiv.org/abs/2312.02145)、[Lotus-2](https://huggingface.co/papers/2512.01030)、[SDPose](https://tsliang.top/SDPose/) などです。
+画像生成モデルの事前知識を活用して、CV タスクに応用する研究はいくつもあります。代表的なものでいえば、[Marigold](https://marigoldmonodepth.github.io/)、[Lotus-2](https://huggingface.co/papers/2512.01030)、[SDPose](https://tsliang.top/SDPose/) などです。
 
 これらは事前学習済みの画像生成モデルを利用しているとはいえ、最終的にはそれぞれのタスク専用に設計されています。
 
@@ -119,6 +119,8 @@ amodal segmentation は、対象物の見えている部分だけでなく、隠
 既存データセット、およびこれを直接生成する teacher が手元になかったため、画像生成と画像編集を組み合わせて作成しました。
 
 作成手順:
+
+![](https://gyazo.com/c3daf3c0a5804bf37d4920a95c7dde61){gyazo=image}
 
 1. 明確な subject と、それを自然に隠す occluder が含まれる occlusion scene のプロンプトを GPT-5.5 で作成
 2. Z-Image-Turbo で source image を生成

--- a/src/content/zh/notes/flux2-klein-schematic-lora.md
+++ b/src/content/zh/notes/flux2-klein-schematic-lora.md
@@ -18,7 +18,7 @@ hero:
 
 ![](https://gyazo.com/2bd9f7b01d61bea0658ba82a750f227e){gyazo=image}
 
-利用图像生成模型的先验知识来做 CV 任务的研究有不少。代表性的例子包括 [Marigold](https://arxiv.org/abs/2312.02145)、[Lotus-2](https://huggingface.co/papers/2512.01030)、[SDPose](https://tsliang.top/SDPose/) 等。
+利用图像生成模型的先验知识来做 CV 任务的研究有不少。代表性的例子包括 [Marigold](https://marigoldmonodepth.github.io/)、[Lotus-2](https://huggingface.co/papers/2512.01030)、[SDPose](https://tsliang.top/SDPose/) 等。
 
 这些方法虽然利用了预训练图像生成模型，但最终仍然是为各自任务专门设计的。
 
@@ -115,6 +115,8 @@ amodal segmentation 是为对象创建 mask 的任务，不只包含可见部分
 手头没有现成数据集，也没有能直接生成它的 teacher，所以这次结合图像生成和图像编辑来制作。
 
 制作流程：
+
+![](https://gyazo.com/c3daf3c0a5804bf37d4920a95c7dde61){gyazo=image}
 
 1. 让 GPT-5.5 创建包含明确 subject 和自然 occluder 的 occlusion scene prompt
 2. 用 Z-Image-Turbo 生成 source image


### PR DESCRIPTION
## Summary
- Point the Marigold mention in the FLUX.2 [klein] Schematic LoRA note to the official project page.
- Add the amodal segmentation process image to the Japanese, English, and Chinese versions.

## Checks
- git diff --check
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Marigold reference links in multilingual notes (English, Japanese, Chinese versions).
  * Added illustrative images to Amodal Segmentation dataset creation sections in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->