### PR TITLE
Add Ideogram 4.0 workflow article

### DIFF
--- a/ops/adr/2026-06-10-ideogram-4-draft.md
+++ b/ops/adr/2026-06-10-ideogram-4-draft.md
@@ -20,12 +20,17 @@ Add a Japanese draft page at:
 
 - `src/content/ja/basic-workflows/ideogram-4.md`
 
+After explicit owner request, add translations at:
+
+- `src/content/en/basic-workflows/ideogram-4.md`
+- `src/content/zh/basic-workflows/ideogram-4.md`
+
 Place it under **Basic Workflows > Other Foundation Models > Ideogram 4.0**, immediately after PixelDiT / PiD.
 
 The page should stay focused on the ComfyUI workflow and practical reading of Ideogram 4.0 rather than becoming a full architecture paper summary.
 
 ## Consequences
 
-- The initial page is JA only unless EN/ZH translations are explicitly requested.
+- EN/ZH translations were added after explicit owner request.
 - No existing slugs are renamed.
 - Workflow explanation can use `mediaRow` blocks because the owner requested that format for the more complex workflow explanation.

--- a/ops/adr/2026-06-10-ideogram-4-draft.md
+++ b/ops/adr/2026-06-10-ideogram-4-draft.md
@@ -1,0 +1,31 @@
+# ADR: Ideogram 4.0 Draft Page
+
+## Status
+
+Accepted
+
+## Context
+
+The owner requested a new Japanese draft article for Ideogram 4.0 based on:
+
+- Official Ideogram 4.0 documentation and release material
+- https://scrapbox.io/work4ai/Ideogram_4.0
+- https://scrapbox.io/work4ai/%F0%9F%A6%8AIdeogram_4.0
+
+The owner requested the page be placed below PixelDiT / PiD in the navigation.
+
+## Decision
+
+Add a Japanese draft page at:
+
+- `src/content/ja/basic-workflows/ideogram-4.md`
+
+Place it under **Basic Workflows > Other Foundation Models > Ideogram 4.0**, immediately after PixelDiT / PiD.
+
+The page should stay focused on the ComfyUI workflow and practical reading of Ideogram 4.0 rather than becoming a full architecture paper summary.
+
+## Consequences
+
+- The initial page is JA only unless EN/ZH translations are explicitly requested.
+- No existing slugs are renamed.
+- Workflow explanation can use `mediaRow` blocks because the owner requested that format for the more complex workflow explanation.

--- a/ops/ia.md
+++ b/ops/ia.md
@@ -143,6 +143,7 @@
     * Z-Image（親ページあり）
       * Z-Image-Turbo
     * PixelDiT / PiD
+    * Ideogram 4.0
   * アップスケール・修正 — 親ページあり
     * ESRGAN
     * GFPGAN

--- a/src/_data/nav.en.yml
+++ b/src/_data/nav.en.yml
@@ -303,6 +303,8 @@ sections:
                 title: Z-Image-Turbo
           - id: pixeldit-pid
             title: PixelDiT / PiD
+          - id: ideogram-4
+            title: Ideogram 4.0
       - id: upscale-fix
         title: Upscale & Fix
         noLink: true

--- a/src/_data/nav.ja.yml
+++ b/src/_data/nav.ja.yml
@@ -303,6 +303,8 @@ sections:
                 title: Z-Image-Turbo
           - id: pixeldit-pid
             title: PixelDiT / PiD
+          - id: ideogram-4
+            title: Ideogram 4.0
       - id: upscale-fix
         title: アップスケール・修正
         noLink: true

--- a/src/_data/nav.zh.yml
+++ b/src/_data/nav.zh.yml
@@ -303,6 +303,8 @@ sections:
         title: Z-Image-Turbo
     - id: pixeldit-pid
       title: PixelDiT / PiD
+    - id: ideogram-4
+      title: Ideogram 4.0
   - id: upscale-fix
     title: 放大与修复
     noLink: true

--- a/src/content/en/basic-workflows/ideogram-4.md
+++ b/src/content/en/basic-workflows/ideogram-4.md
@@ -1,0 +1,161 @@
+---
+layout: page.njk
+lang: en
+section: basic-workflows
+slug: ideogram-4
+navId: ideogram-4
+title: "Ideogram 4.0"
+created: 2026-06-10
+updated: 2026-06-10
+summary: "Image generation with Ideogram 4.0"
+permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
+hero:
+  image: "https://i.gyazo.com/cb9116562b7693e120aa63eafef11769.png"
+tags: []
+---
+
+## What is Ideogram 4.0?
+
+[Ideogram 4.0](https://ideogram.ai/models/4.0/) is a 9.3B DiT-based model.
+
+Its main feature is that it uses JSON-style captions, allowing fairly detailed control over elements inside the image.
+
+There was a similar model called [FIBO](https://github.com/Bria-AI/FIBO), but Ideogram 4.0 is stronger at BBOX coordinate instructions and color specification. It is suited to DTP-like design tasks such as posters, logos, UI, and packaging.
+
+In exchange for that control, it may not be the most casual model. You need to write prompts in the expected format to get its intended performance.
+
+---
+
+## Model Download
+
+- diffusion_models
+  - [ideogram4_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/diffusion_models/ideogram4_fp8_scaled.safetensors) (9.28 GB)
+  - [ideogram4_nvfp4_mixed.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/diffusion_models/ideogram4_nvfp4_mixed.safetensors) (5.49 GB)
+  - [ideogram4_unconditional_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/diffusion_models/ideogram4_unconditional_fp8_scaled.safetensors) (9.28 GB)
+  - [ideogram4_unconditional_nvfp4_mixed.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/diffusion_models/ideogram4_unconditional_nvfp4_mixed.safetensors) (5.49 GB)
+- text_encoders
+  - [qwen3vl_8b_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/text_encoders/qwen3vl_8b_fp8_scaled.safetensors) (10.6 GB)
+- vae
+  - [flux2-vae.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/vae/flux2-vae.safetensors) (336 MB)
+
+```text
+📂ComfyUI/
+└── 📂models/
+    ├── 📂diffusion_models/
+    │   ├── ideogram4_fp8_scaled.safetensors
+    │   ├── ideogram4_nvfp4_mixed.safetensors
+    │   ├── ideogram4_unconditional_fp8_scaled.safetensors
+    │   └── ideogram4_unconditional_nvfp4_mixed.safetensors
+    ├── 📂text_encoders/
+    │   └── qwen3vl_8b_fp8_scaled.safetensors
+    └── 📂vae/
+        └── flux2-vae.safetensors
+```
+
+I will explain the details later, but because it loads two Diffusion models, it is quite heavy.
+
+ComfyUI manages memory internally, so lack of VRAM does not always mean it cannot generate at all, but it can take a very long time.
+
+`nvfp4` is an option to make it lighter, but quality drops.
+
+The `unconditional` side has less impact on quality, so using `fp8` for the normal side and `nvfp4` for the `unconditional` side may be a good balance.
+
+---
+
+## Prompt
+
+Plain natural language can generate images, but without following the expected JSON schema, the quality will not really come out.
+
+The basic form looks like this.
+
+```json
+{
+  "high_level_description": "Overall 1-2 sentence description of the image.",
+  "style_description": {
+    "aesthetics": "Mood and aesthetic direction.",
+    "lighting": "Lighting.",
+    "medium": "illustration / photograph / graphic_design, etc.",
+    "art_style": "Art style for non-photographic images.",
+    "color_palette": ["#FFFFFF", "#000000"]
+  },
+  "compositional_deconstruction": {
+    "background": "Background and environment description.",
+    "elements": [
+      {
+        "type": "obj",
+        "bbox": [100, 200, 800, 700],
+        "desc": "Description of an object, person, or element.",
+        "color_palette": ["#FFFFFF", "#000000"]
+      },
+      {
+        "type": "text",
+        "bbox": [820, 200, 920, 800],
+        "text": "HELLO",
+        "desc": "Description of the text appearance.",
+        "color_palette": ["#000000"]
+      }
+    ]
+  }
+}
+```
+
+The structure itself is simple: overall description, style, background, and descriptions for each element. Still, writing this by hand every time is not realistic.
+
+The coordinates are especially annoying. You need to specify where each element should go using BBOX, and imagining that in your head is almost impossible.
+
+So here are a few ways to create the prompt.
+
+### Let an LLM Handle It
+
+The easiest way is to pass the official [Prompting Guide](https://github.com/ideogram-oss/ideogram4/blob/main/docs/prompting.md) and a description of the image you want to an LLM, and have it convert the request into a JSON caption.
+
+You can also give it reference images or a rough sketch you made.
+
+Local models that can run inside ComfyUI usually are not strong enough for this, so it is better to rely on ChatGPT, Gemini, and similar tools.
+
+![](https://gyazo.com/b314abc36bec096b81fb3231a2687064){gyazo=image}
+
+- [Sample chat with ChatGPT](https://chatgpt.com/share/6a28f7cc-e934-8320-86d6-f790a5274389)
+
+### Use a Dedicated Prompt Builder
+
+Another option is to use a dedicated prompt builder and create the prompt visually.
+
+For example, [ComfyUI-KJNodes](https://github.com/kijai/ComfyUI-KJNodes) includes a commonly used node called `Ideogram 4 Prompt Builder KJ`.
+
+![](https://gyazo.com/a1c3a269983b478c1f605e2f0a5c6e4f){gyazo=image}
+
+- Set the generated image size, then enter the background and style fields.
+- Drag in the region field to create a BBOX, then set the prompt and color code for what you want drawn there.
+
+---
+
+## text2image
+
+![](https://gyazo.com/c9a2cf1717e87cd1ba28c5d236a02b4d){gyazo=image}
+
+[](/workflows/basic-workflows/ideogram-4/Ideogram_4.0_text2image.json)
+
+{% mediaRow img="https://gyazo.com/c0d5e9131313e7c3c5255b4f54d55dbb {gyazo=image}", width=33, align="left" %}
+**Load Diffusion Model**
+
+Ideogram 4.0 loads two diffusion models for its slightly unusual CFG.
+
+- In normal [CFG](/en/ai-capabilities/cfg/), the result with a prompt and the result without a prompt are compared, pushing the generation toward the prompt.
+- Ideogram 4.0 does not use a simple empty prompt on the unconditional side. It uses the model side that has no text condition.
+- It is easy to wonder what the difference is, but you can think of it as a trick for handling the positive prompt more delicately.
+
+{% endmediaRow %}
+
+{% mediaRow img="https://gyazo.com/26ef78ed5bf868ab5ca9a62b643640ff {gyazo=image}", width=33, align="left" %}
+**CFG**
+
+This is an old small technique, but the CFG value changes between the first and second half of sampling.
+
+- In this workflow, the first half is CFG 7, and the second half is CFG 3.
+- Rather than applying high CFG from start to finish, weakening it partway through tends to be more stable.
+- `CFG Override` is the node used for this.
+- It overrides the CFG value only for the specified step range.
+- In this workflow, `cfg` becomes 3 after 70% of the total steps.
+
+{% endmediaRow %}

--- a/src/content/en/basic-workflows/ideogram-4.md
+++ b/src/content/en/basic-workflows/ideogram-4.md
@@ -136,6 +136,8 @@ For example, [ComfyUI-KJNodes](https://github.com/kijai/ComfyUI-KJNodes) include
 
 [](/workflows/basic-workflows/ideogram-4/Ideogram_4.0_text2image.json)
 
+Aside from the prompt, there are a few parts that are slightly different from a normal workflow, so let's look only at those.
+
 {% mediaRow img="https://gyazo.com/c0d5e9131313e7c3c5255b4f54d55dbb {gyazo=image}", width=33, align="left" %}
 **Load Diffusion Model**
 

--- a/src/content/en/news.md
+++ b/src/content/en/news.md
@@ -5,7 +5,7 @@ slug: news
 navId: news
 title: "News"
 created: 2026-01-15
-updated: 2026-06-09
+updated: 2026-06-10
 summary: "Site updates"
 permalink: "/{{ lang }}/{{ slug }}/"
 tags:
@@ -13,6 +13,11 @@ tags:
 ---
 
 <div class="news-list">
+  <a class="news-row" href="/en/basic-workflows/ideogram-4/">
+    <span class="news-row__date">2026.6.10</span>
+    <span class="news-row__tag">basic-workflows</span>
+    <span class="news-row__title">Added Ideogram 4.0 page</span>
+  </a>
   <a class="news-row" href="/en/basic-workflows/pixeldit-pid/">
     <span class="news-row__date">2026.6.9</span>
     <span class="news-row__tag">basic-workflows</span>

--- a/src/content/ja/basic-workflows/ideogram-4.md
+++ b/src/content/ja/basic-workflows/ideogram-4.md
@@ -1,0 +1,192 @@
+---
+layout: page.njk
+lang: ja
+section: basic-workflows
+slug: ideogram-4
+navId: ideogram-4
+title: "Ideogram 4.0"
+created: 2026-06-10
+updated: 2026-06-10
+summary: "Ideogram 4.0での画像生成"
+permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
+hero:
+  image: "https://i.gyazo.com/b282bac27265443a567d4e3e462d71c2.png"
+tags: []
+---
+
+## Ideogram 4.0とは？
+
+**[Ideogram 4.0](https://ideogram.ai/models/4.0/)** は、Ideogram が公開した open weight の画像生成モデルです。
+
+とくに、文字を含むデザイン、ポスター、ロゴ、DTP 的なレイアウトに強いモデルです。
+
+モデル自体は 9.3B の DiT 系モデルで、既存モデルの fine-tune や蒸留ではなく、最初から学習されています。
+
+テキストエンコーダには **Qwen3-VL-8B-Instruct** が使われています。
+最終層だけを見るのではなく、13 個の中間層の hidden states を結合して DiT に渡す構成になっており、文字列そのものだけでなく、構図や意味の理解をかなり強めに使う設計です。
+
+もうひとつ大きいのが、プロンプトです。
+
+普通の自然文プロンプトでも動きますが、Ideogram 4.0 は **構造化 JSON caption** で学習されています。
+そのため、自然文でふわっと書くより、文字、色、配置、背景、要素ごとの説明を JSON として書いたほうが本来の性能を出しやすくなります。
+
+---
+
+## モデルのダウンロード
+
+公式の重みは Hugging Face で公開されています。
+
+- [ideogram-ai/ideogram-4-nf4](https://huggingface.co/ideogram-ai/ideogram-4-nf4)
+- [ideogram-ai/ideogram-4-fp8](https://huggingface.co/ideogram-ai/ideogram-4-fp8)
+- [ideogram-ai/ideogram-4-nf4-diffusers](https://huggingface.co/ideogram-ai/ideogram-4-nf4-diffusers)
+
+Hugging Face の gated model なので、事前にモデルページで利用条件に同意し、Hugging Face の token でログインしておく必要があります。
+
+```bash
+hf auth login
+```
+
+ComfyUI で使う場合の配置は、使う実装や workflow 側の参照名に合わせます。
+
+---
+
+## JSON prompt
+
+Ideogram 4.0 は、普通のプロンプトではなく **JSON で絵を説明する** ほうが本筋です。
+
+最低限見るところは、この三つです。
+
+- `high_level_description`
+  - 画像全体を一文〜二文で説明します。
+- `style_description`
+  - 写真なのか、イラストなのか、デザインなのか、色、光、画風を指定します。
+- `compositional_deconstruction`
+  - 背景と、画像内の要素を細かく分けて書きます。
+
+文字を入れたい場合は、`elements` の中に `type: "text"` として書きます。
+
+```json
+{
+  "type": "text",
+  "bbox": [120, 180, 240, 820],
+  "text": "COMFY WITH COMFYUI",
+  "desc": "Large bold white sans-serif title text centered near the top."
+}
+```
+
+`bbox` は、画像の中でどこに置くかを指定するための座標です。
+
+`[y_min, x_min, y_max, x_max]` の順で、0〜1000 の正規化座標として書きます。
+
+このへんが Ideogram 4.0 らしいところですね。
+普通の画像生成モデルに「左上にロゴ、中央に大きい文字、下に小さい注釈」と言うより、かなり DTP に近い感覚で指定できます。
+
+---
+
+## Magic Prompt
+
+毎回 JSON を手で書くのは面倒なので、公式実装には **Magic Prompt** があります。
+
+自然文プロンプトを LLM で構造化 JSON caption に変換する仕組みです。
+
+公式の `run_inference.py` では、デフォルトで `ideogram-4-v1` の Magic Prompt を使えます。
+これは Ideogram の hosted API 側で展開されるため、`IDEOGRAM_API_KEY` が必要です。
+
+```bash
+python run_inference.py \
+  --prompt "a poster for a small coffee shop opening in Tokyo" \
+  --output out.png \
+  --quantization "nf4" \
+  --magic-prompt-key "$IDEOGRAM_API_KEY"
+```
+
+システムプロンプト自体は公開されているため、別の LLM で JSON caption を作ることもできます。
+ただし、公式がテストしている経路とは結果が変わる可能性があります。
+
+---
+
+## workflow
+
+Ideogram 4.0 の workflow は、普通の text2image より **プロンプトをどう作るか** が分かりにくいです。
+
+{% mediaRow img="https://gyazo.com/b282bac27265443a567d4e3e462d71c2 {gyazo=image}", width=60, align="left" %}
+**全体の流れ**
+
+- 自然文プロンプトをそのまま使うこともできます。
+- ただし、本来は JSON caption を作ってからモデルへ渡すほうが向いています。
+- ComfyUI 上では、自然文プロンプト、Magic Prompt、JSON caption のどこを触っているのかを分けて見ると理解しやすいです。
+
+{% endmediaRow %}
+
+### 自然文で書く場合
+
+まずは普通に書いて構いません。
+
+ただし、Ideogram 4.0 は JSON caption で学習されているため、自然文だけだと、細かいレイアウト指定や文字配置は弱くなりやすいです。
+
+### JSONで書く場合
+
+文字、色、配置をちゃんと制御したい場合はこちらです。
+
+- `text` に実際に描かせたい文字を書く
+- `desc` に書体、サイズ感、位置、周囲との関係を書く
+- `bbox` で置き場所を指定する
+- `color_palette` で全体や要素ごとの色を寄せる
+
+`bbox` や `color_palette` が専用の制御画像として入っているわけではありません。
+あくまで JSON 文字列を Qwen3-VL が読み、それを DiT に渡しています。
+
+そのため、ControlNet のように厳密なレイアウト制御をしているというより、**モデルが読みやすい形式でレイアウトを説明している** と考えたほうが近いです。
+
+---
+
+## Asymmetric CFG
+
+Ideogram 4.0 では、**Asymmetric CFG** という CFG が使われています。
+
+計算式自体は、通常の [CFG](/ja/ai-capabilities/cfg/) と大きく変わりません。
+
+ただし、unconditional 側で空プロンプトを渡すのではなく、テキスト token を除去した状態を使います。
+空文字も「空文字という条件」なので、そこをもう少しきれいに分けている、と考えると分かりやすいです。
+
+---
+
+## パラメータ
+
+公式実装には、いくつかの sampler preset があります。
+
+- `V4_QUALITY_48`
+  - 48 steps
+  - 品質優先
+- `V4_DEFAULT_20`
+  - 20 steps
+  - 標準
+- `V4_TURBO_12`
+  - 12 steps
+  - 速度優先
+
+解像度は、縦横とも 16 の倍数で、256〜2048 の範囲をサポートしています。
+アスペクト比は 6:1 まで対応しているので、正方形だけでなく、横長バナーや縦長ポスターにも向いています。
+
+最高品質を狙うなら 2048px と `V4_QUALITY_48` ですが、当然かなり重くなります。
+まずは 1024px 前後で挙動を見てから上げるのが無難です。
+
+---
+
+## 注意点
+
+- NSFW prompt はブロックされます。
+- 非 JSON の自然文プロンプトでは、Safety filter の false positive が出やすいと公式ドキュメントに書かれています。
+- 公開重みの利用条件は、Hugging Face のモデルページで確認してください。
+- JSON の key order や hex color の形式は、公式の Prompting Guide に合わせたほうが安定します。
+
+---
+
+## 参考
+
+- [Ideogram 4.0](https://ideogram.ai/models/4.0/)
+- [Ideogram 4.0 Technical Details](https://ideogram.ai/blog/ideogram-4.0/)
+- [ideogram-oss/ideogram4](https://github.com/ideogram-oss/ideogram4)
+- [Prompting Guide](https://github.com/ideogram-oss/ideogram4/blob/main/docs/prompting.md)
+- [Inference Reference](https://github.com/ideogram-oss/ideogram4/blob/main/docs/inference.md)
+- [Ideogram 4 Hugging Face collection](https://huggingface.co/collections/ideogram-ai/ideogram-4)

--- a/src/content/ja/basic-workflows/ideogram-4.md
+++ b/src/content/ja/basic-workflows/ideogram-4.md
@@ -10,183 +10,152 @@ updated: 2026-06-10
 summary: "Ideogram 4.0での画像生成"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:
-  image: "https://i.gyazo.com/b282bac27265443a567d4e3e462d71c2.png"
+  image: "https://i.gyazo.com/cb9116562b7693e120aa63eafef11769.png"
 tags: []
 ---
 
 ## Ideogram 4.0とは？
 
-**[Ideogram 4.0](https://ideogram.ai/models/4.0/)** は、Ideogram が公開した open weight の画像生成モデルです。
+[Ideogram 4.0](https://ideogram.ai/models/4.0/) は、9.3B の DiT 系モデルです。
 
-とくに、文字を含むデザイン、ポスター、ロゴ、DTP 的なレイアウトに強いモデルです。
+最大の特徴は、JSON 形式のキャプションを使うことで、画像内の要素をかなり細かく指定できる点です。
 
-モデル自体は 9.3B の DiT 系モデルで、既存モデルの fine-tune や蒸留ではなく、最初から学習されています。
+似たようなアプローチで [FIBO](https://github.com/Bria-AI/FIBO) というモデルがありましたが、Ideogram 4.0 は BBOX による座標指定や色指定に強く、ポスター、ロゴ、UI、パッケージのような、DTP 寄りのデザインタスクに向いています。
 
-テキストエンコーダには **Qwen3-VL-8B-Instruct** が使われています。
-最終層だけを見るのではなく、13 個の中間層の hidden states を結合して DiT に渡す構成になっており、文字列そのものだけでなく、構図や意味の理解をかなり強めに使う設計です。
-
-もうひとつ大きいのが、プロンプトです。
-
-普通の自然文プロンプトでも動きますが、Ideogram 4.0 は **構造化 JSON caption** で学習されています。
-そのため、自然文でふわっと書くより、文字、色、配置、背景、要素ごとの説明を JSON として書いたほうが本来の性能を出しやすくなります。
+コントロール性能と引き換えに、既定の形式でプロンプトを書かなければ本来の性能が出ないので、手軽なモデルではないかもしれませんね。
 
 ---
 
 ## モデルのダウンロード
 
-公式の重みは Hugging Face で公開されています。
+- diffusion_models
+  - [ideogram4_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/diffusion_models/ideogram4_fp8_scaled.safetensors) (9.28 GB)
+  - [ideogram4_nvfp4_mixed.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/diffusion_models/ideogram4_nvfp4_mixed.safetensors) (5.49 GB)
+  - [ideogram4_unconditional_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/diffusion_models/ideogram4_unconditional_fp8_scaled.safetensors) (9.28 GB)
+  - [ideogram4_unconditional_nvfp4_mixed.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/diffusion_models/ideogram4_unconditional_nvfp4_mixed.safetensors) (5.49 GB)
+- text_encoders
+  - [qwen3vl_8b_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/text_encoders/qwen3vl_8b_fp8_scaled.safetensors) (10.6 GB)
+- vae
+  - [flux2-vae.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/vae/flux2-vae.safetensors) (336 MB)
 
-- [ideogram-ai/ideogram-4-nf4](https://huggingface.co/ideogram-ai/ideogram-4-nf4)
-- [ideogram-ai/ideogram-4-fp8](https://huggingface.co/ideogram-ai/ideogram-4-fp8)
-- [ideogram-ai/ideogram-4-nf4-diffusers](https://huggingface.co/ideogram-ai/ideogram-4-nf4-diffusers)
-
-Hugging Face の gated model なので、事前にモデルページで利用条件に同意し、Hugging Face の token でログインしておく必要があります。
-
-```bash
-hf auth login
+```text
+📂ComfyUI/
+└── 📂models/
+    ├── 📂diffusion_models/
+    │   ├── ideogram4_fp8_scaled.safetensors
+    │   ├── ideogram4_nvfp4_mixed.safetensors
+    │   ├── ideogram4_unconditional_fp8_scaled.safetensors
+    │   └── ideogram4_unconditional_nvfp4_mixed.safetensors
+    ├── 📂text_encoders/
+    │   └── qwen3vl_8b_fp8_scaled.safetensors
+    └── 📂vae/
+        └── flux2-vae.safetensors
 ```
 
-ComfyUI で使う場合の配置は、使う実装や workflow 側の参照名に合わせます。
+詳細はあとで説明しますが、2 つの Diffusion model を読み込む仕組みのため、かなり重いです。
+
+ComfyUI は内部でやりくりしてくれるので、VRAM が足りなくても、まったく生成できないわけではありませんが、非常に時間がかかります。
+
+軽くするために `nvfp4` を使う選択肢もありますが、品質は落ちます。
+
+`unconditional` 側は品質への影響が少ないので、通常側は `fp8`、`unconditional` 側は `nvfp4` を使うのが良いかもしれません。
 
 ---
 
-## JSON prompt
+## プロンプト
 
-Ideogram 4.0 は、普通のプロンプトではなく **JSON で絵を説明する** ほうが本筋です。
+単なる自然文でも生成はできますが、既定の JSON schema に従わないと、まともにクオリティが出ません。
 
-最低限見るところは、この三つです。
-
-- `high_level_description`
-  - 画像全体を一文〜二文で説明します。
-- `style_description`
-  - 写真なのか、イラストなのか、デザインなのか、色、光、画風を指定します。
-- `compositional_deconstruction`
-  - 背景と、画像内の要素を細かく分けて書きます。
-
-文字を入れたい場合は、`elements` の中に `type: "text"` として書きます。
+基本形はこのようになっています。
 
 ```json
 {
-  "type": "text",
-  "bbox": [120, 180, 240, 820],
-  "text": "COMFY WITH COMFYUI",
-  "desc": "Large bold white sans-serif title text centered near the top."
+  "high_level_description": "画像全体の1〜2文の説明。",
+  "style_description": {
+    "aesthetics": "雰囲気、審美性。",
+    "lighting": "ライティング。",
+    "medium": "illustration / photograph / graphic_design など。",
+    "art_style": "非写真の場合の画風。",
+    "color_palette": ["#FFFFFF", "#000000"]
+  },
+  "compositional_deconstruction": {
+    "background": "背景・環境の説明。",
+    "elements": [
+      {
+        "type": "obj",
+        "bbox": [100, 200, 800, 700],
+        "desc": "物体・人物・要素の説明。",
+        "color_palette": ["#FFFFFF", "#000000"]
+      },
+      {
+        "type": "text",
+        "bbox": [820, 200, 920, 800],
+        "text": "HELLO",
+        "desc": "文字の見た目の説明。",
+        "color_palette": ["#000000"]
+      }
+    ]
+  }
 }
 ```
 
-`bbox` は、画像の中でどこに置くかを指定するための座標です。
+全体の説明、スタイル、背景、各要素の説明、と構成自体はシンプルですが、こんなものを毎回手で書いてはいられません。
 
-`[y_min, x_min, y_max, x_max]` の順で、0〜1000 の正規化座標として書きます。
+特に座標指定は面倒です。画像のどのあたりに、どの要素を置くのかを BBOX で指定する必要があるため、それを頭で想像するのはほぼ無理です。
 
-このへんが Ideogram 4.0 らしいところですね。
-普通の画像生成モデルに「左上にロゴ、中央に大きい文字、下に小さい注釈」と言うより、かなり DTP に近い感覚で指定できます。
+そこで、いくつかプロンプトを作成するための方法を紹介します。
+
+### LLM に任せる
+
+一番楽なのは、公式の[プロンプトガイド](https://github.com/ideogram-oss/ideogram4/blob/main/docs/prompting.md) と、作りたい画像の説明を LLM に渡して、JSON キャプションに変換してもらう方法です。
+
+参考画像だったり、自分が書いたラフを渡して作ってもらってもいいですね。
+
+ComfyUI 上で動かせるレベルのローカルモデルでは性能が足りないので、大人しく ChatGPT や Gemini などに頼った方が良いでしょう。
+
+![](https://gyazo.com/b314abc36bec096b81fb3231a2687064){gyazo=image}
+
+- [サンプルチャット with ChatGPT](https://chatgpt.com/share/6a28f7cc-e934-8320-86d6-f790a5274389)
+
+### 専用プロンプトビルダーを使う
+
+専用のプロンプトビルダーを使って、視覚的にプロンプトを作る手もあります。
+
+例えば [ComfyUI-KJNodes](https://github.com/kijai/ComfyUI-KJNodes) の `Ideogram 4 Prompt Builder KJ` ノードはよく使われているものの一つです。
+
+![](https://gyazo.com/a1c3a269983b478c1f605e2f0a5c6e4f){gyazo=image}
+
+- 生成する画像のサイズを設定し、背景やスタイルといったものを入力していきます。
+- region 欄でドラッグすると、BBOX を作ることができ、そこに描かせたいもののプロンプト、及びカラーコードを設定します。
 
 ---
 
-## Magic Prompt
+## text2image
 
-毎回 JSON を手で書くのは面倒なので、公式実装には **Magic Prompt** があります。
+![](https://gyazo.com/c9a2cf1717e87cd1ba28c5d236a02b4d){gyazo=image}
 
-自然文プロンプトを LLM で構造化 JSON caption に変換する仕組みです。
+[](/workflows/basic-workflows/ideogram-4/Ideogram_4.0_text2image.json)
 
-公式の `run_inference.py` では、デフォルトで `ideogram-4-v1` の Magic Prompt を使えます。
-これは Ideogram の hosted API 側で展開されるため、`IDEOGRAM_API_KEY` が必要です。
+{% mediaRow img="https://gyazo.com/c0d5e9131313e7c3c5255b4f54d55dbb {gyazo=image}", width=33, align="left" %}
+**Load Diffusion Model**
 
-```bash
-python run_inference.py \
-  --prompt "a poster for a small coffee shop opening in Tokyo" \
-  --output out.png \
-  --quantization "nf4" \
-  --magic-prompt-key "$IDEOGRAM_API_KEY"
-```
+Ideogram 4.0 では、少し特殊な CFG のために diffusion model を 2 つ読み込みます。
 
-システムプロンプト自体は公開されているため、別の LLM で JSON caption を作ることもできます。
-ただし、公式がテストしている経路とは結果が変わる可能性があります。
-
----
-
-## workflow
-
-Ideogram 4.0 の workflow は、普通の text2image より **プロンプトをどう作るか** が分かりにくいです。
-
-{% mediaRow img="https://gyazo.com/b282bac27265443a567d4e3e462d71c2 {gyazo=image}", width=60, align="left" %}
-**全体の流れ**
-
-- 自然文プロンプトをそのまま使うこともできます。
-- ただし、本来は JSON caption を作ってからモデルへ渡すほうが向いています。
-- ComfyUI 上では、自然文プロンプト、Magic Prompt、JSON caption のどこを触っているのかを分けて見ると理解しやすいです。
+- 通常の [CFG](/ja/ai-capabilities/cfg/) では、プロンプトありの結果と、プロンプトなしの結果を比べることで、プロンプト方向へ生成を寄せます。
+- 一方で Ideogram 4.0 では、unconditional 側に単なる空プロンプトを使うのではなく、テキスト条件を持たない側のモデルを使います。
+- なにが違うんだという感じもしますが、より positive prompt を繊細に扱うための工夫といった感じでしょうか。
 
 {% endmediaRow %}
 
-### 自然文で書く場合
+{% mediaRow img="https://gyazo.com/26ef78ed5bf868ab5ca9a62b643640ff {gyazo=image}", width=33, align="left" %}
+**CFG**
 
-まずは普通に書いて構いません。
+昔からある細かいテクニックですが、サンプリングの前半と後半で CFG の値を変えます。
 
-ただし、Ideogram 4.0 は JSON caption で学習されているため、自然文だけだと、細かいレイアウト指定や文字配置は弱くなりやすいです。
+- この workflow では、前半が CFG 7、後半は CFG 3
+- 高い CFG を最初から最後までかけ続けるより、途中で弱めたほうが安定するんですね。
+- そのために使用するのが `CFG Override` ノードです。
+- 指定したステップ範囲だけ CFG の値を上書きします。
+- この workflow では、全体の 70% 以降は cfg が 3 になります。
 
-### JSONで書く場合
-
-文字、色、配置をちゃんと制御したい場合はこちらです。
-
-- `text` に実際に描かせたい文字を書く
-- `desc` に書体、サイズ感、位置、周囲との関係を書く
-- `bbox` で置き場所を指定する
-- `color_palette` で全体や要素ごとの色を寄せる
-
-`bbox` や `color_palette` が専用の制御画像として入っているわけではありません。
-あくまで JSON 文字列を Qwen3-VL が読み、それを DiT に渡しています。
-
-そのため、ControlNet のように厳密なレイアウト制御をしているというより、**モデルが読みやすい形式でレイアウトを説明している** と考えたほうが近いです。
-
----
-
-## Asymmetric CFG
-
-Ideogram 4.0 では、**Asymmetric CFG** という CFG が使われています。
-
-計算式自体は、通常の [CFG](/ja/ai-capabilities/cfg/) と大きく変わりません。
-
-ただし、unconditional 側で空プロンプトを渡すのではなく、テキスト token を除去した状態を使います。
-空文字も「空文字という条件」なので、そこをもう少しきれいに分けている、と考えると分かりやすいです。
-
----
-
-## パラメータ
-
-公式実装には、いくつかの sampler preset があります。
-
-- `V4_QUALITY_48`
-  - 48 steps
-  - 品質優先
-- `V4_DEFAULT_20`
-  - 20 steps
-  - 標準
-- `V4_TURBO_12`
-  - 12 steps
-  - 速度優先
-
-解像度は、縦横とも 16 の倍数で、256〜2048 の範囲をサポートしています。
-アスペクト比は 6:1 まで対応しているので、正方形だけでなく、横長バナーや縦長ポスターにも向いています。
-
-最高品質を狙うなら 2048px と `V4_QUALITY_48` ですが、当然かなり重くなります。
-まずは 1024px 前後で挙動を見てから上げるのが無難です。
-
----
-
-## 注意点
-
-- NSFW prompt はブロックされます。
-- 非 JSON の自然文プロンプトでは、Safety filter の false positive が出やすいと公式ドキュメントに書かれています。
-- 公開重みの利用条件は、Hugging Face のモデルページで確認してください。
-- JSON の key order や hex color の形式は、公式の Prompting Guide に合わせたほうが安定します。
-
----
-
-## 参考
-
-- [Ideogram 4.0](https://ideogram.ai/models/4.0/)
-- [Ideogram 4.0 Technical Details](https://ideogram.ai/blog/ideogram-4.0/)
-- [ideogram-oss/ideogram4](https://github.com/ideogram-oss/ideogram4)
-- [Prompting Guide](https://github.com/ideogram-oss/ideogram4/blob/main/docs/prompting.md)
-- [Inference Reference](https://github.com/ideogram-oss/ideogram4/blob/main/docs/inference.md)
-- [Ideogram 4 Hugging Face collection](https://huggingface.co/collections/ideogram-ai/ideogram-4)
+{% endmediaRow %}

--- a/src/content/ja/basic-workflows/ideogram-4.md
+++ b/src/content/ja/basic-workflows/ideogram-4.md
@@ -136,6 +136,8 @@ ComfyUI 上で動かせるレベルのローカルモデルでは性能が足り
 
 [](/workflows/basic-workflows/ideogram-4/Ideogram_4.0_text2image.json)
 
+プロンプト以外にも、一般的な workflow と比べると少し特殊な部分があるので、そちらだけ見ていきましょう。
+
 {% mediaRow img="https://gyazo.com/c0d5e9131313e7c3c5255b4f54d55dbb {gyazo=image}", width=33, align="left" %}
 **Load Diffusion Model**
 

--- a/src/content/ja/news.md
+++ b/src/content/ja/news.md
@@ -5,13 +5,18 @@ slug: news
 navId: news
 title: "更新情報"
 created: 2026-01-15
-updated: 2026-06-09
+updated: 2026-06-10
 summary: "このサイトの更新情報"
 permalink: "/{{ lang }}/{{ slug }}/"
 tags:
   - news
 ---
 <div class="news-list">
+  <a class="news-row" href="/ja/basic-workflows/ideogram-4/">
+    <span class="news-row__date">2026.6.10</span>
+    <span class="news-row__tag">basic-workflows</span>
+    <span class="news-row__title">Ideogram 4.0 のページを追加しました</span>
+  </a>
   <a class="news-row" href="/ja/basic-workflows/pixeldit-pid/">
     <span class="news-row__date">2026.6.9</span>
     <span class="news-row__tag">basic-workflows</span>

--- a/src/content/zh/basic-workflows/ideogram-4.md
+++ b/src/content/zh/basic-workflows/ideogram-4.md
@@ -136,6 +136,8 @@ ComfyUI 内部会处理显存，所以 VRAM 不够也不一定完全不能生成
 
 [](/workflows/basic-workflows/ideogram-4/Ideogram_4.0_text2image.json)
 
+除了提示词以外，它和普通 workflow 相比还有几个稍微特殊的地方，所以这里只看这些部分。
+
 {% mediaRow img="https://gyazo.com/c0d5e9131313e7c3c5255b4f54d55dbb {gyazo=image}", width=33, align="left" %}
 **Load Diffusion Model**
 

--- a/src/content/zh/basic-workflows/ideogram-4.md
+++ b/src/content/zh/basic-workflows/ideogram-4.md
@@ -1,0 +1,161 @@
+---
+layout: page.njk
+lang: zh
+section: basic-workflows
+slug: ideogram-4
+navId: ideogram-4
+title: "Ideogram 4.0"
+created: 2026-06-10
+updated: 2026-06-10
+summary: "使用 Ideogram 4.0 进行图像生成"
+permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
+hero:
+  image: "https://i.gyazo.com/cb9116562b7693e120aa63eafef11769.png"
+tags: []
+---
+
+## Ideogram 4.0 是什么？
+
+[Ideogram 4.0](https://ideogram.ai/models/4.0/) 是一个 9.3B 的 DiT 系模型。
+
+它最大的特点是使用 JSON 形式的 caption，可以比较细地指定图像里的各个元素。
+
+以前也有类似思路的 [FIBO](https://github.com/Bria-AI/FIBO)，但 Ideogram 4.0 更擅长用 BBOX 指定坐标，也更擅长颜色指定。海报、Logo、UI、包装这类偏 DTP 的设计任务，会比较适合它。
+
+作为交换，它可能不是那种随手就很好用的模型。提示词必须按既定格式写，才能发挥出本来的效果。
+
+---
+
+## 模型下载
+
+- diffusion_models
+  - [ideogram4_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/diffusion_models/ideogram4_fp8_scaled.safetensors) (9.28 GB)
+  - [ideogram4_nvfp4_mixed.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/diffusion_models/ideogram4_nvfp4_mixed.safetensors) (5.49 GB)
+  - [ideogram4_unconditional_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/diffusion_models/ideogram4_unconditional_fp8_scaled.safetensors) (9.28 GB)
+  - [ideogram4_unconditional_nvfp4_mixed.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/diffusion_models/ideogram4_unconditional_nvfp4_mixed.safetensors) (5.49 GB)
+- text_encoders
+  - [qwen3vl_8b_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/text_encoders/qwen3vl_8b_fp8_scaled.safetensors) (10.6 GB)
+- vae
+  - [flux2-vae.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/vae/flux2-vae.safetensors) (336 MB)
+
+```text
+📂ComfyUI/
+└── 📂models/
+    ├── 📂diffusion_models/
+    │   ├── ideogram4_fp8_scaled.safetensors
+    │   ├── ideogram4_nvfp4_mixed.safetensors
+    │   ├── ideogram4_unconditional_fp8_scaled.safetensors
+    │   └── ideogram4_unconditional_nvfp4_mixed.safetensors
+    ├── 📂text_encoders/
+    │   └── qwen3vl_8b_fp8_scaled.safetensors
+    └── 📂vae/
+        └── flux2-vae.safetensors
+```
+
+细节后面再说，因为它会读取两个 Diffusion model，所以相当重。
+
+ComfyUI 内部会处理显存，所以 VRAM 不够也不一定完全不能生成，但可能会非常慢。
+
+想减轻负担，可以使用 `nvfp4`，不过画质会下降。
+
+`unconditional` 侧对质量的影响相对小一些，所以普通侧用 `fp8`，`unconditional` 侧用 `nvfp4`，可能是比较合适的平衡。
+
+---
+
+## 提示词
+
+只用普通自然语言也能生成，但如果不按既定的 JSON schema 来写，质量很难出来。
+
+基本形式如下。
+
+```json
+{
+  "high_level_description": "图像整体的 1～2 句说明。",
+  "style_description": {
+    "aesthetics": "氛围、审美方向。",
+    "lighting": "光照。",
+    "medium": "illustration / photograph / graphic_design 等。",
+    "art_style": "非照片时的画风。",
+    "color_palette": ["#FFFFFF", "#000000"]
+  },
+  "compositional_deconstruction": {
+    "background": "背景、环境说明。",
+    "elements": [
+      {
+        "type": "obj",
+        "bbox": [100, 200, 800, 700],
+        "desc": "物体、人物、元素说明。",
+        "color_palette": ["#FFFFFF", "#000000"]
+      },
+      {
+        "type": "text",
+        "bbox": [820, 200, 920, 800],
+        "text": "HELLO",
+        "desc": "文字外观说明。",
+        "color_palette": ["#000000"]
+      }
+    ]
+  }
+}
+```
+
+整体说明、风格、背景、各元素说明，结构本身并不复杂。但每次都手写这种东西，还是不太现实。
+
+尤其是坐标指定很麻烦。每个元素要放在图像的哪里，都要用 BBOX 指定，光靠脑子想象基本不可能。
+
+所以这里介绍几种生成提示词的方法。
+
+### 交给 LLM
+
+最轻松的方法，是把官方的 [Prompting Guide](https://github.com/ideogram-oss/ideogram4/blob/main/docs/prompting.md) 和想做的图像说明交给 LLM，让它转换成 JSON caption。
+
+也可以把参考图，或者自己画的草图一起丢给它。
+
+能在 ComfyUI 里本地跑的模型，一般能力不太够，所以还是老老实实交给 ChatGPT、Gemini 之类会比较好。
+
+![](https://gyazo.com/b314abc36bec096b81fb3231a2687064){gyazo=image}
+
+- [Sample chat with ChatGPT](https://chatgpt.com/share/6a28f7cc-e934-8320-86d6-f790a5274389)
+
+### 使用专用提示词构建器
+
+也可以使用专用的提示词构建器，视觉化地制作提示词。
+
+例如 [ComfyUI-KJNodes](https://github.com/kijai/ComfyUI-KJNodes) 里的 `Ideogram 4 Prompt Builder KJ` 节点，就是比较常用的一个。
+
+![](https://gyazo.com/a1c3a269983b478c1f605e2f0a5c6e4f){gyazo=image}
+
+- 设置生成图像的尺寸，然后填写背景、风格等内容。
+- 在 region 栏拖动即可创建 BBOX，并为该区域设置想画的内容提示词和颜色代码。
+
+---
+
+## text2image
+
+![](https://gyazo.com/c9a2cf1717e87cd1ba28c5d236a02b4d){gyazo=image}
+
+[](/workflows/basic-workflows/ideogram-4/Ideogram_4.0_text2image.json)
+
+{% mediaRow img="https://gyazo.com/c0d5e9131313e7c3c5255b4f54d55dbb {gyazo=image}", width=33, align="left" %}
+**Load Diffusion Model**
+
+Ideogram 4.0 为了稍微特殊的 CFG，会读取两个 diffusion model。
+
+- 普通的 [CFG](/zh/ai-capabilities/cfg/) 是比较有提示词的结果和没有提示词的结果，把生成方向往提示词靠。
+- Ideogram 4.0 的 unconditional 侧不是使用单纯的空提示词，而是使用不带文本条件的那一侧模型。
+- 乍看可能会觉得这有什么区别，但可以把它理解成一种更细致处理 positive prompt 的办法。
+
+{% endmediaRow %}
+
+{% mediaRow img="https://gyazo.com/26ef78ed5bf868ab5ca9a62b643640ff {gyazo=image}", width=33, align="left" %}
+**CFG**
+
+这是很早就有的小技巧：采样前半段和后半段使用不同的 CFG 值。
+
+- 这个 workflow 里，前半段是 CFG 7，后半段是 CFG 3。
+- 与其从头到尾一直套很高的 CFG，中途降下来通常更稳定。
+- 这里使用的是 `CFG Override` 节点。
+- 它只会在指定的 step 范围内覆盖 CFG 值。
+- 这个 workflow 里，总步数 70% 之后，`cfg` 会变成 3。
+
+{% endmediaRow %}

--- a/src/content/zh/news.md
+++ b/src/content/zh/news.md
@@ -5,13 +5,18 @@ slug: news
 navId: news
 title: "更新信息"
 created: 2026-02-05
-updated: 2026-06-09
+updated: 2026-06-10
 summary: "本站的更新信息"
 permalink: "/{{ lang }}/{{ slug }}/"
 tags:
   - news
 ---
 <div class="news-list">
+  <a class="news-row" href="/zh/basic-workflows/ideogram-4/">
+    <span class="news-row__date">2026.6.10</span>
+    <span class="news-row__tag">basic-workflows</span>
+    <span class="news-row__title">追加了 Ideogram 4.0 的页面</span>
+  </a>
   <a class="news-row" href="/zh/basic-workflows/pixeldit-pid/">
     <span class="news-row__date">2026.6.9</span>
     <span class="news-row__tag">basic-workflows</span>

--- a/src/workflows/basic-workflows/ideogram-4/Ideogram_4.0_text2image.json
+++ b/src/workflows/basic-workflows/ideogram-4/Ideogram_4.0_text2image.json
@@ -1,0 +1,889 @@
+{
+  "id": "d8034549-7e0a-40f1-8c2e-de3ffc6f1cae",
+  "revision": 0,
+  "last_node_id": 109,
+  "last_link_id": 172,
+  "nodes": [
+    {
+      "id": 76,
+      "type": "KSamplerSelect",
+      "pos": [
+        560.1252292712549,
+        324.6528974302894
+      ],
+      "size": [
+        270,
+        68.88020833333334
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "SAMPLER",
+          "type": "SAMPLER",
+          "links": [
+            132
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "KSamplerSelect",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.56",
+        "enableTabs": false,
+        "tabWidth": 65,
+        "tabXOffset": 10,
+        "hasSecondTab": false,
+        "secondTabText": "Send Back",
+        "secondTabOffset": 80,
+        "secondTabWidth": 65
+      },
+      "widgets_values": [
+        "euler"
+      ]
+    },
+    {
+      "id": 8,
+      "type": "VAEDecode",
+      "pos": [
+        1180.6146240234375,
+        195.84114925861235
+      ],
+      "size": [
+        157.56002807617188,
+        46
+      ],
+      "flags": {},
+      "order": 15,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 164
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 76
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [
+            101
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAEDecode",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 92,
+      "type": "EmptyFlux2LatentImage",
+      "pos": [
+        560.1252292712549,
+        721.3543590454891
+      ],
+      "size": [
+        270,
+        106
+      ],
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "width",
+          "type": "INT",
+          "widget": {
+            "name": "width"
+          },
+          "link": 153
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "widget": {
+            "name": "height"
+          },
+          "link": 154
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            152
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "EmptyFlux2LatentImage"
+      },
+      "widgets_values": [
+        1024,
+        1024,
+        1
+      ]
+    },
+    {
+      "id": 88,
+      "type": "DualModelGuider",
+      "pos": [
+        560.1252292712549,
+        119.74227078935617
+      ],
+      "size": [
+        270,
+        118
+      ],
+      "flags": {},
+      "order": 13,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 172
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 146
+        },
+        {
+          "name": "model_negative",
+          "shape": 7,
+          "type": "MODEL",
+          "link": 149
+        },
+        {
+          "name": "negative",
+          "shape": 7,
+          "type": "CONDITIONING",
+          "link": 145
+        }
+      ],
+      "outputs": [
+        {
+          "name": "GUIDER",
+          "type": "GUIDER",
+          "links": [
+            144
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "DualModelGuider"
+      },
+      "widgets_values": [
+        7
+      ]
+    },
+    {
+      "id": 91,
+      "type": "CLIPLoader",
+      "pos": [
+        -510.80318076960083,
+        311.42496280403503
+      ],
+      "size": [
+        289.8073985431536,
+        106
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [
+            150
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": [
+        "qwen3vl_8b_fp8_scaled.safetensors",
+        "ideogram4",
+        "default"
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 39,
+      "type": "VAELoader",
+      "pos": [
+        904.0583918587276,
+        72.88171068869869
+      ],
+      "size": [
+        242.12760404770165,
+        58
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "slot_index": 0,
+          "links": [
+            76
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAELoader",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "flux2-vae.safetensors"
+      ],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 90,
+      "type": "UNETLoader",
+      "pos": [
+        -96.592885685151,
+        131.5898766922886
+      ],
+      "size": [
+        305.3782043457031,
+        82
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            149
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "UNETLoader",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "ideogram4_unconditional_nvfp4_mixed.safetensors",
+        "default"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 87,
+      "type": "ConditioningZeroOut",
+      "pos": [
+        278.5119793477361,
+        427.0196777116257
+      ],
+      "size": [
+        211.88658923633488,
+        26
+      ],
+      "flags": {},
+      "order": 12,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "conditioning",
+          "type": "CONDITIONING",
+          "link": 142
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            145
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ConditioningZeroOut"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 79,
+      "type": "SamplerCustomAdvanced",
+      "pos": [
+        904.0583918587276,
+        195.84114925861235
+      ],
+      "size": [
+        242.12760404770165,
+        106
+      ],
+      "flags": {},
+      "order": 14,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "noise",
+          "type": "NOISE",
+          "link": 130
+        },
+        {
+          "name": "guider",
+          "type": "GUIDER",
+          "link": 144
+        },
+        {
+          "name": "sampler",
+          "type": "SAMPLER",
+          "link": 132
+        },
+        {
+          "name": "sigmas",
+          "type": "SIGMAS",
+          "link": 167
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 152
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "type": "LATENT",
+          "links": [
+            164
+          ]
+        },
+        {
+          "name": "denoised_output",
+          "type": "LATENT",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "SamplerCustomAdvanced",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.60",
+        "enableTabs": false,
+        "tabWidth": 65,
+        "tabXOffset": 10,
+        "hasSecondTab": false,
+        "secondTabText": "Send Back",
+        "secondTabOffset": 80,
+        "secondTabWidth": 65
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 95,
+      "type": "Ideogram4Scheduler",
+      "pos": [
+        560.1252292712549,
+        480.44373240455593
+      ],
+      "size": [
+        270,
+        154
+      ],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "width",
+          "type": "INT",
+          "widget": {
+            "name": "width"
+          },
+          "link": 156
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "widget": {
+            "name": "height"
+          },
+          "link": 157
+        }
+      ],
+      "outputs": [
+        {
+          "name": "SIGMAS",
+          "type": "SIGMAS",
+          "links": [
+            167
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "Ideogram4Scheduler"
+      },
+      "widgets_values": [
+        20,
+        1024,
+        1024,
+        0,
+        1.75
+      ]
+    },
+    {
+      "id": 56,
+      "type": "SaveImage",
+      "pos": [
+        1371.5615738427737,
+        195.84114925861235
+      ],
+      "size": [
+        436.7195313170437,
+        711.2421298391242
+      ],
+      "flags": {},
+      "order": 16,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 101
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.75"
+      },
+      "widgets_values": [
+        "ComfyUI"
+      ]
+    },
+    {
+      "id": 94,
+      "type": "ResolutionSelector",
+      "pos": [
+        249.45527396590353,
+        701.3543590454891
+      ],
+      "size": [
+        270,
+        126
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "width",
+          "type": "INT",
+          "links": [
+            153,
+            156
+          ]
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "links": [
+            154,
+            157
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ResolutionSelector"
+      },
+      "widgets_values": [
+        "2:3 (Portrait Photo)",
+        1,
+        16
+      ]
+    },
+    {
+      "id": 83,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -194.71785512781273,
+        311.42496280403503
+      ],
+      "size": [
+        408.34315901785703,
+        324.50164397511764
+      ],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 150
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            142,
+            146
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.56",
+        "enableTabs": false,
+        "tabWidth": 65,
+        "tabXOffset": 10,
+        "hasSecondTab": false,
+        "secondTabText": "Send Back",
+        "secondTabOffset": 80,
+        "secondTabWidth": 65
+      },
+      "widgets_values": [
+        "{\n  \"high_level_description\": \"A cinematic Leica-style twilight photograph shows a tall modern office tower from a dramatic low angle, rising against a deep evening sky. Warm illuminated rooms on the front facade spell \\\"Comfy,\\\" while a small handwritten \\\"Ideogram 4.0\\\" signature appears at the lower right.\",\n  \"style_description\": {\n    \"aesthetics\": \"cinematic, atmospheric, elegant, slightly dreamy, high-end urban photography with strong vertical composition and restrained visual clutter\",\n    \"lighting\": \"blue-hour ambient light with soft haze, gentle street glow near the lower frame, and warm yellow interior window lights standing out against the dark facade\",\n    \"photo\": \"shot like a Leica photograph with a low-angle perspective, subtle filmic contrast, crisp architectural lines, natural depth, and a refined editorial cityscape look\",\n    \"medium\": \"photograph\",\n    \"color_palette\": [\"#1E2148\", \"#4A3F7E\", \"#F3E34B\", \"#C8CEDF\", \"#6E314D\"]\n  },\n  \"compositional_deconstruction\": {\n    \"background\": \"A dusky urban evening sky fills most of the frame with deep navy and violet tones, fading slightly brighter near the horizon. The atmosphere is lightly hazy, with a soft bloom of city light near the lower left. Minimal surrounding street-level structures appear as subdued silhouettes near the bottom edges, keeping the tower dominant in the portrait-oriented composition.\",\n    \"elements\": [\n      {\n        \"type\": \"obj\",\n        \"bbox\": [120, 330, 945, 845],\n        \"desc\": \"A tall dark-glass office tower viewed from below, centered slightly right of frame. The building has sharp modern edges, horizontal floor bands, a subtly reflective facade, and a tapering sense of height emphasized by the perspective. The front-facing plane is the main visual surface, while the right side recedes into shadow.\",\n        \"color_palette\": [\"#161A33\", \"#252C54\", \"#BEC6DC\"]\n      },\n      {\n        \"type\": \"text\",\n        \"bbox\": [170, 455, 785, 615],\n        \"text\": \"Comfy\",\n        \"desc\": \"The word is formed by warm glowing room windows arranged vertically on the front facade of the tower. Each letter is clearly legible through clusters of illuminated office rooms, appearing as bright yellow typographic shapes embedded within the architecture.\",\n        \"color_palette\": [\"#F3E34B\"]\n      },\n      {\n        \"type\": \"obj\",\n        \"bbox\": [40, 85, 90, 130],\n        \"desc\": \"A small crescent moon in the upper left portion of the sky, softly glowing and isolated against the dark twilight background.\",\n        \"color_palette\": [\"#F3E34B\", \"#F8F0A8\"]\n      },\n      {\n        \"type\": \"text\",\n        \"bbox\": [955, 790, 995, 985],\n        \"text\": \"Ideogram 4.0\",\n        \"desc\": \"A small handwritten signature placed at the lower right corner, rendered in a light ink-like white script with a casual, unobtrusive appearance.\",\n        \"color_palette\": [\"#F3F3F0\"]\n      }\n    ]\n  }\n}"
+      ]
+    },
+    {
+      "id": 78,
+      "type": "RandomNoise",
+      "pos": [
+        560.1252292712549,
+        -49.16835585157703
+      ],
+      "size": [
+        270,
+        82
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "NOISE",
+          "type": "NOISE",
+          "links": [
+            130
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "RandomNoise",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.56",
+        "enableTabs": false,
+        "tabWidth": 65,
+        "tabXOffset": 10,
+        "hasSecondTab": false,
+        "secondTabText": "Send Back",
+        "secondTabOffset": 80,
+        "secondTabWidth": 65
+      },
+      "widgets_values": [
+        9999,
+        "fixed"
+      ]
+    },
+    {
+      "id": 37,
+      "type": "UNETLoader",
+      "pos": [
+        -96.592885685151,
+        -49.16835585157703
+      ],
+      "size": [
+        305.3782043457031,
+        82
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            148
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "UNETLoader",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "ideogram4_fp8_scaled.safetensors",
+        "default"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 89,
+      "type": "CFGOverride",
+      "pos": [
+        249.45527396590353,
+        -49.16835585157703
+      ],
+      "size": [
+        270,
+        106
+      ],
+      "flags": {},
+      "order": 11,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 148
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            172
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CFGOverride"
+      },
+      "widgets_values": [
+        3,
+        0.7,
+        1
+      ]
+    },
+    {
+      "id": 71,
+      "type": "MarkdownNote",
+      "pos": [
+        -560.0606701629572,
+        -141.99890306621
+      ],
+      "size": [
+        402.9868769880169,
+        355.5887797584986
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "## models\n\n- diffusion_models\n  - [ideogram4_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/diffusion_models/ideogram4_fp8_scaled.safetensors) (9.28 GB)\n  - [ideogram4_nvfp4_mixed.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/diffusion_models/ideogram4_nvfp4_mixed.safetensors) (5.49 GB)\n  - [ideogram4_unconditional_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/diffusion_models/ideogram4_unconditional_fp8_scaled.safetensors) (9.28 GB)\n  - [ideogram4_unconditional_nvfp4_mixed.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/diffusion_models/ideogram4_unconditional_nvfp4_mixed.safetensors) (5.49 GB)\n- text_encoders\n  - [qwen3vl_8b_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/text_encoders/qwen3vl_8b_fp8_scaled.safetensors) (10.6 GB)\n- vae\n  - [flux2-vae.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/vae/flux2-vae.safetensors) (336 MB)\n\n```text\n📂ComfyUI/\n└── 📂models/\n    ├── 📂diffusion_models/\n    │   ├── ideogram4_fp8_scaled.safetensors\n    │   ├── ideogram4_nvfp4_mixed.safetensors\n    │   ├── ideogram4_unconditional_fp8_scaled.safetensors\n    │   └── ideogram4_unconditional_nvfp4_mixed.safetensors\n    ├── 📂text_encoders/\n    │   └── qwen3vl_8b_fp8_scaled.safetensors\n    └── 📂vae/\n         └── flux2-vae.safetensors\n```"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    }
+  ],
+  "links": [
+    [
+      76,
+      39,
+      0,
+      8,
+      1,
+      "VAE"
+    ],
+    [
+      101,
+      8,
+      0,
+      56,
+      0,
+      "IMAGE"
+    ],
+    [
+      130,
+      78,
+      0,
+      79,
+      0,
+      "NOISE"
+    ],
+    [
+      132,
+      76,
+      0,
+      79,
+      2,
+      "SAMPLER"
+    ],
+    [
+      142,
+      83,
+      0,
+      87,
+      0,
+      "CONDITIONING"
+    ],
+    [
+      144,
+      88,
+      0,
+      79,
+      1,
+      "GUIDER"
+    ],
+    [
+      145,
+      87,
+      0,
+      88,
+      3,
+      "CONDITIONING"
+    ],
+    [
+      146,
+      83,
+      0,
+      88,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      148,
+      37,
+      0,
+      89,
+      0,
+      "MODEL"
+    ],
+    [
+      149,
+      90,
+      0,
+      88,
+      2,
+      "MODEL"
+    ],
+    [
+      150,
+      91,
+      0,
+      83,
+      0,
+      "CLIP"
+    ],
+    [
+      152,
+      92,
+      0,
+      79,
+      4,
+      "LATENT"
+    ],
+    [
+      153,
+      94,
+      0,
+      92,
+      0,
+      "INT"
+    ],
+    [
+      154,
+      94,
+      1,
+      92,
+      1,
+      "INT"
+    ],
+    [
+      156,
+      94,
+      0,
+      95,
+      0,
+      "INT"
+    ],
+    [
+      157,
+      94,
+      1,
+      95,
+      1,
+      "INT"
+    ],
+    [
+      164,
+      79,
+      0,
+      8,
+      0,
+      "LATENT"
+    ],
+    [
+      167,
+      95,
+      0,
+      79,
+      3,
+      "SIGMAS"
+    ],
+    [
+      172,
+      89,
+      0,
+      88,
+      0,
+      "MODEL"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.6209213230591553,
+      "offset": [
+        821.830919056688,
+        383.46442973242
+      ]
+    },
+    "frontendVersion": "1.45.15",
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true
+  },
+  "version": 0.4
+}


### PR DESCRIPTION
## Summary

- Add the Japanese Ideogram 4.0 workflow article with model placement, prompt notes, and text2image workflow explanation.
- Add English and Chinese translations and navigation entries.
- Add the Ideogram 4.0 workflow JSON and news entries.
- Record the IA/content decision in the ADR.

## Validation

- `git diff --check`
- `python3 -m json.tool src/workflows/basic-workflows/ideogram-4/Ideogram_4.0_text2image.json`
- `npm run build`
- Confirmed generated JA/EN/ZH pages and news links include the Ideogram 4.0 article and workflow download UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive Ideogram 4.0 documentation in English, Japanese, and Chinese with model installation instructions, JSON prompt schema, and workflow guidance.
  * Introduced Ideogram 4.0 ComfyUI text-to-image workflow template with CFG override capabilities.

* **Documentation**
  * Updated navigation and announcements across all supported languages to feature the new Ideogram 4.0 resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->