### PR TITLE
Clarify Ideogram 4.0 unconditional wording

### DIFF
--- a/src/content/en/basic-workflows/ideogram-4.md
+++ b/src/content/en/basic-workflows/ideogram-4.md
@@ -144,7 +144,7 @@ Aside from the prompt, there are a few parts that are slightly different from a 
 Ideogram 4.0 loads two diffusion models for its slightly unusual CFG.
 
 - In normal [CFG](/en/ai-capabilities/cfg/), the result with a prompt and the result without a prompt are compared, pushing the generation toward the prompt.
-- Ideogram 4.0 does not use a simple empty prompt on the unconditional side. It uses the model side that has no text condition.
+- Ideogram 4.0 does not pass an empty prompt to the unconditional side. Instead, it sends image-only input, without text tokens, through the unconditional model.
 - It is easy to wonder what the difference is, but you can think of it as a trick for handling the positive prompt more delicately.
 
 {% endmediaRow %}

--- a/src/content/ja/basic-workflows/ideogram-4.md
+++ b/src/content/ja/basic-workflows/ideogram-4.md
@@ -144,7 +144,7 @@ ComfyUI 上で動かせるレベルのローカルモデルでは性能が足り
 Ideogram 4.0 では、少し特殊な CFG のために diffusion model を 2 つ読み込みます。
 
 - 通常の [CFG](/ja/ai-capabilities/cfg/) では、プロンプトありの結果と、プロンプトなしの結果を比べることで、プロンプト方向へ生成を寄せます。
-- 一方で Ideogram 4.0 では、unconditional 側に単なる空プロンプトを使うのではなく、テキスト条件を持たない側のモデルを使います。
+- 一方で Ideogram 4.0 では、unconditional 側に空プロンプトを渡すのではなく、テキスト token を使わない image-only の入力を unconditional 用モデルに通します。
 - なにが違うんだという感じもしますが、より positive prompt を繊細に扱うための工夫といった感じでしょうか。
 
 {% endmediaRow %}

--- a/src/content/zh/basic-workflows/ideogram-4.md
+++ b/src/content/zh/basic-workflows/ideogram-4.md
@@ -144,7 +144,7 @@ ComfyUI 内部会处理显存，所以 VRAM 不够也不一定完全不能生成
 Ideogram 4.0 为了稍微特殊的 CFG，会读取两个 diffusion model。
 
 - 普通的 [CFG](/zh/ai-capabilities/cfg/) 是比较有提示词的结果和没有提示词的结果，把生成方向往提示词靠。
-- Ideogram 4.0 的 unconditional 侧不是使用单纯的空提示词，而是使用不带文本条件的那一侧模型。
+- Ideogram 4.0 的 unconditional 侧不是传入空提示词，而是把不使用文本 token 的 image-only 输入送入 unconditional 用模型。
 - 乍看可能会觉得这有什么区别，但可以把它理解成一种更细致处理 positive prompt 的办法。
 
 {% endmediaRow %}


### PR DESCRIPTION
## Summary

- Clarify the Ideogram 4.0 CFG explanation in Japanese, English, and Chinese.
- Replace the vague "model side without text condition" wording with a safer description: image-only input without text tokens is passed through the unconditional model.

## Validation

- `git diff --check`
- `npm run build`
- Confirmed the generated JA/EN/ZH pages include the corrected wording.