### PR TITLE
Add SCAIL-2 long animation workflow

### DIFF
--- a/src/content/en/basic-workflows/scail-2.md
+++ b/src/content/en/basic-workflows/scail-2.md
@@ -68,7 +68,7 @@ Rather than humans building a complicated processing pipeline by hand, it is oft
 
 Move a **reference image** using a motion video.
 
-![](https://gyazo.com/a7c76588147896b9357481a741f1b071){gyazo=image}
+![](https://gyazo.com/3f28188680b010f2bce1a13858ccaf9f){gyazo=image}
 
 [](/workflows/basic-workflows/scail-2/SCAIL-2_Animation.json)
 
@@ -116,7 +116,7 @@ Mask the people in the reference image and motion video with [SAM 3 / 3.1](/en/d
 
 {% endmediaRow %}
 
-{% mediaRow img="https://gyazo.com/2ed39327ee5ef67944b787be81605b08 {gyazo=image}", width=33, align="left" %}
+{% mediaRow img="https://gyazo.com/608eb36831300427187be280cf45c420 {gyazo=image}", width=33, align="left" %}
 **Create SCAIL-2 Colored Mask**
 
 The generated masks are colored appropriately.
@@ -145,7 +145,7 @@ SCAIL-2 can also use the Lightx2v LoRA for [fast Wan2.1 generation](/en/basic-wo
 
 Replace the **person in the video** with the **person in the reference image**.
 
-![](https://gyazo.com/0996965c611a4b4ad46f3490b27ad1d6){gyazo=image}
+![](https://gyazo.com/6ade374ea0cbcb2175889cdc0be0bc46){gyazo=image}
 
 [](/workflows/basic-workflows/scail-2/SCAIL-2_Replacement.json)
 
@@ -160,7 +160,7 @@ Replacement uses the video size as the base.
 
 {% endmediaRow %}
 
-{% mediaRow img="https://gyazo.com/48e4ebae5076eba223dda97a3853dc67 {gyazo=image}", width=33, align="left" %}
+{% mediaRow img="https://gyazo.com/cfdb30273c14347f30aad0d2c9987f8c {gyazo=image}", width=33, align="left" %}
 **Create SCAIL-2 Colored Mask and WanSCAILToVideo**
 
 Set `replacement_mode` to `true`.
@@ -171,7 +171,7 @@ Set `replacement_mode` to `true`.
 
 **Output Example**
 
-![motion video](https://gyazo.com/f14aef04ac197a4b92680e05c4fbd178){gyazo=loop} ![reference image](https://gyazo.com/ce9827f452cdc3cf7d47de8b12996f28){gyazo=image} ![output](https://gyazo.com/65599272e59ffa6edd7571f1b87db822){gyazo=loop}
+![motion video](https://gyazo.com/395fd549274fb126d836ac0a9414d07d){gyazo=loop} ![reference image](https://gyazo.com/ce9827f452cdc3cf7d47de8b12996f28){gyazo=image} ![output](https://gyazo.com/1a7caa57ded15aee5700bed072a4a0a7){gyazo=loop}
 
 ---
 
@@ -181,11 +181,11 @@ SCAIL-2 also supports videos and images with multiple people.
 
 No special operation is required. As before, just input the video and reference image.
 
-![](https://gyazo.com/86b498dff06f09754116fc3cce4d3dbd){gyazo=image}
+![](https://gyazo.com/a04e322f84ca4377479a7760a60436cd){gyazo=image}
 
 [](/workflows/basic-workflows/scail-2/SCAIL-2_Animation_multi-char.json)
 
-{% mediaRow img="https://gyazo.com/28c7b669ac66155518bbce22130e623b {gyazo=image}", width=33, align="left" %}
+{% mediaRow img="https://gyazo.com/86e8ccd07a045bb039e2e69b81b2781b {gyazo=image}", width=33, align="left" %}
 **Create SCAIL-2 Colored Mask**
 
 When there are multiple people, it becomes important to control which person should follow which motion. SCAIL-2 uses colored masks for this.
@@ -200,3 +200,27 @@ When there are multiple people, it becomes important to control which person sho
 **Output Example**
 
 ![reference image](https://gyazo.com/567acaf722ca9e839ec7cb834c1ed344){gyazo=image} ![motion video](https://gyazo.com/53461ca17746349fbd11e69798460ea6){gyazo=loop} ![output](https://gyazo.com/913ff446dd39fa33f56ba9ed07ce6e16){gyazo=loop}
+
+---
+
+## Animation Mode (Over 81 Frames)
+
+SCAIL-2 basically generates up to 81 frames, but with `WAN Context Windows (Manual)`, you can generate longer videos by splitting along the time direction.
+
+![](https://gyazo.com/43b5c2e2684957795ab7d80f8ce9976a){gyazo=image}
+
+[](/workflows/basic-workflows/scail-2/SCAIL-2_Animation_WAN-Context-Windows.json)
+
+{% mediaRow img="https://gyazo.com/55aa8d3ccee17c3a43f87f17895ebfb1 {gyazo=image}", width=33, align="left" %}
+**WAN Context Windows (Manual)**
+
+It is like tiling along the time axis, or context sliding.
+
+- Set `context_length` to 81, and it generates internally in chunks of 81 frames.
+- If you leave it as-is, the seams will be obvious, so set an appropriate number of frames in `context_overlap` as overlap.
+
+{% endmediaRow %}
+
+**Output Example**
+
+![reference image](https://gyazo.com/ce9827f452cdc3cf7d47de8b12996f28){gyazo=image} ![motion video](https://gyazo.com/5491ba090036cbac5d76abd293d842ef){gyazo=loop} ![output](https://gyazo.com/ae5729a3c9c70711f767364534ccedf9){gyazo=loop}

--- a/src/content/ja/basic-workflows/scail-2.md
+++ b/src/content/ja/basic-workflows/scail-2.md
@@ -68,7 +68,7 @@ ViTPose や OpenPose で棒人間を作り、それを条件として人物を�
 
 **参照画像** をモーション用動画で動かします。
 
-![](https://gyazo.com/a7c76588147896b9357481a741f1b071){gyazo=image}
+![](https://gyazo.com/3f28188680b010f2bce1a13858ccaf9f){gyazo=image}
 
 [](/workflows/basic-workflows/scail-2/SCAIL-2_Animation.json)
 
@@ -116,7 +116,7 @@ ViTPose や OpenPose で棒人間を作り、それを条件として人物を�
 
 {% endmediaRow %}
 
-{% mediaRow img="https://gyazo.com/2ed39327ee5ef67944b787be81605b08 {gyazo=image}", width=33, align="left" %}
+{% mediaRow img="https://gyazo.com/608eb36831300427187be280cf45c420 {gyazo=image}", width=33, align="left" %}
 **Create SCAIL-2 Colored Mask**
 
 作ったマスクが適切に色付けされます。
@@ -145,7 +145,7 @@ SCAIL-2 でも、[Wan2.1 の高速生成](/ja/basic-workflows/wan-2-1/#self-forc
 
 **動画内の人物** を **参照画像の人物** に入れ替えます。
 
-![](https://gyazo.com/0996965c611a4b4ad46f3490b27ad1d6){gyazo=image}
+![](https://gyazo.com/6ade374ea0cbcb2175889cdc0be0bc46){gyazo=image}
 
 [](/workflows/basic-workflows/scail-2/SCAIL-2_Replacement.json)
 
@@ -160,7 +160,7 @@ Replacement は動画のサイズが基準になります。
 
 {% endmediaRow %}
 
-{% mediaRow img="https://gyazo.com/48e4ebae5076eba223dda97a3853dc67 {gyazo=image}", width=33, align="left" %}
+{% mediaRow img="https://gyazo.com/cfdb30273c14347f30aad0d2c9987f8c {gyazo=image}", width=33, align="left" %}
 **Create SCAIL-2 Colored Mask と WanSCAILToVideo**
 
 `replacement_mode` を `true` にします。
@@ -171,7 +171,7 @@ Replacement は動画のサイズが基準になります。
 
 **出力例**
 
-![モーション用動画](https://gyazo.com/f14aef04ac197a4b92680e05c4fbd178){gyazo=loop} ![参照画像](https://gyazo.com/ce9827f452cdc3cf7d47de8b12996f28){gyazo=image} ![output](https://gyazo.com/65599272e59ffa6edd7571f1b87db822){gyazo=loop}
+![モーション用動画](https://gyazo.com/395fd549274fb126d836ac0a9414d07d){gyazo=loop} ![参照画像](https://gyazo.com/ce9827f452cdc3cf7d47de8b12996f28){gyazo=image} ![output](https://gyazo.com/1a7caa57ded15aee5700bed072a4a0a7){gyazo=loop}
 
 ---
 
@@ -181,11 +181,11 @@ SCAIL-2 は複数人の動画・画像にも対応しています。
 
 特別な操作は必要ありません。これまでと同様に動画と参照画像を入力するだけです。
 
-![](https://gyazo.com/86b498dff06f09754116fc3cce4d3dbd){gyazo=image}
+![](https://gyazo.com/a04e322f84ca4377479a7760a60436cd){gyazo=image}
 
 [](/workflows/basic-workflows/scail-2/SCAIL-2_Animation_multi-char.json)
 
-{% mediaRow img="https://gyazo.com/28c7b669ac66155518bbce22130e623b {gyazo=image}", width=33, align="left" %}
+{% mediaRow img="https://gyazo.com/86e8ccd07a045bb039e2e69b81b2781b {gyazo=image}", width=33, align="left" %}
 **Create SCAIL-2 Colored Mask**
 
 複数人の場合は、どの人物にどの動きを対応させるかが重要になりますが、SCAIL-2 では色付きマスクを使ってそれを制御します。
@@ -200,3 +200,27 @@ SCAIL-2 は複数人の動画・画像にも対応しています。
 **出力例**
 
 ![参照画像](https://gyazo.com/567acaf722ca9e839ec7cb834c1ed344){gyazo=image} ![モーション用動画](https://gyazo.com/53461ca17746349fbd11e69798460ea6){gyazo=loop} ![output](https://gyazo.com/913ff446dd39fa33f56ba9ed07ce6e16){gyazo=loop}
+
+---
+
+## Animation モード (81 フレーム以上)
+
+SCAIL-2 は基本的に 81 フレームまでの生成ですが、`WAN Context Windows (Manual)` を使うと、時間方向に分割しながら長めの動画を生成できます。
+
+![](https://gyazo.com/43b5c2e2684957795ab7d80f8ce9976a){gyazo=image}
+
+[](/workflows/basic-workflows/scail-2/SCAIL-2_Animation_WAN-Context-Windows.json)
+
+{% mediaRow img="https://gyazo.com/55aa8d3ccee17c3a43f87f17895ebfb1 {gyazo=image}", width=33, align="left" %}
+**WAN Context Windows (Manual)**
+
+時間軸方向のタイリング、あるいは context sliding のようなものです。
+
+- `context_length` を 81 にすると、内部で 81 フレームずつ区切って生成します。
+- そのままだと継ぎ目がはっきり見えてしまうので、のりしろとして `context_overlap` に適当なフレーム数を設定します。
+
+{% endmediaRow %}
+
+**出力例**
+
+![参照画像](https://gyazo.com/ce9827f452cdc3cf7d47de8b12996f28){gyazo=image} ![モーション用動画](https://gyazo.com/5491ba090036cbac5d76abd293d842ef){gyazo=loop} ![output](https://gyazo.com/ae5729a3c9c70711f767364534ccedf9){gyazo=loop}

--- a/src/content/zh/basic-workflows/scail-2.md
+++ b/src/content/zh/basic-workflows/scail-2.md
@@ -68,7 +68,7 @@ tags: ["human-motion-transfer","video-generation"]
 
 用动作视频来驱动 **参考图像**。
 
-![](https://gyazo.com/a7c76588147896b9357481a741f1b071){gyazo=image}
+![](https://gyazo.com/3f28188680b010f2bce1a13858ccaf9f){gyazo=image}
 
 [](/workflows/basic-workflows/scail-2/SCAIL-2_Animation.json)
 
@@ -116,7 +116,7 @@ tags: ["human-motion-transfer","video-generation"]
 
 {% endmediaRow %}
 
-{% mediaRow img="https://gyazo.com/2ed39327ee5ef67944b787be81605b08 {gyazo=image}", width=33, align="left" %}
+{% mediaRow img="https://gyazo.com/608eb36831300427187be280cf45c420 {gyazo=image}", width=33, align="left" %}
 **Create SCAIL-2 Colored Mask**
 
 生成的 mask 会被适当地着色。
@@ -145,7 +145,7 @@ SCAIL-2 也可以使用 [Wan2.1 高速生成](/zh/basic-workflows/wan-2-1/#self-
 
 将 **视频中的人物** 替换为 **参考图像中的人物**。
 
-![](https://gyazo.com/0996965c611a4b4ad46f3490b27ad1d6){gyazo=image}
+![](https://gyazo.com/6ade374ea0cbcb2175889cdc0be0bc46){gyazo=image}
 
 [](/workflows/basic-workflows/scail-2/SCAIL-2_Replacement.json)
 
@@ -160,7 +160,7 @@ Replacement 会以视频尺寸为基准。
 
 {% endmediaRow %}
 
-{% mediaRow img="https://gyazo.com/48e4ebae5076eba223dda97a3853dc67 {gyazo=image}", width=33, align="left" %}
+{% mediaRow img="https://gyazo.com/cfdb30273c14347f30aad0d2c9987f8c {gyazo=image}", width=33, align="left" %}
 **Create SCAIL-2 Colored Mask 与 WanSCAILToVideo**
 
 将 `replacement_mode` 设为 `true`。
@@ -171,7 +171,7 @@ Replacement 会以视频尺寸为基准。
 
 **输出例**
 
-![动作视频](https://gyazo.com/f14aef04ac197a4b92680e05c4fbd178){gyazo=loop} ![参考图像](https://gyazo.com/ce9827f452cdc3cf7d47de8b12996f28){gyazo=image} ![output](https://gyazo.com/65599272e59ffa6edd7571f1b87db822){gyazo=loop}
+![动作视频](https://gyazo.com/395fd549274fb126d836ac0a9414d07d){gyazo=loop} ![参考图像](https://gyazo.com/ce9827f452cdc3cf7d47de8b12996f28){gyazo=image} ![output](https://gyazo.com/1a7caa57ded15aee5700bed072a4a0a7){gyazo=loop}
 
 ---
 
@@ -181,11 +181,11 @@ SCAIL-2 也支持多人视频和图像。
 
 不需要特别操作。和前面一样，输入视频和参考图像即可。
 
-![](https://gyazo.com/86b498dff06f09754116fc3cce4d3dbd){gyazo=image}
+![](https://gyazo.com/a04e322f84ca4377479a7760a60436cd){gyazo=image}
 
 [](/workflows/basic-workflows/scail-2/SCAIL-2_Animation_multi-char.json)
 
-{% mediaRow img="https://gyazo.com/28c7b669ac66155518bbce22130e623b {gyazo=image}", width=33, align="left" %}
+{% mediaRow img="https://gyazo.com/86e8ccd07a045bb039e2e69b81b2781b {gyazo=image}", width=33, align="left" %}
 **Create SCAIL-2 Colored Mask**
 
 多人时，哪个人物对应哪段动作会变得重要。SCAIL-2 使用彩色 mask 来控制这一点。
@@ -200,3 +200,27 @@ SCAIL-2 也支持多人视频和图像。
 **输出例**
 
 ![参考图像](https://gyazo.com/567acaf722ca9e839ec7cb834c1ed344){gyazo=image} ![动作视频](https://gyazo.com/53461ca17746349fbd11e69798460ea6){gyazo=loop} ![output](https://gyazo.com/913ff446dd39fa33f56ba9ed07ce6e16){gyazo=loop}
+
+---
+
+## Animation 模式（81 帧以上）
+
+SCAIL-2 基本上生成到 81 帧为止，但使用 `WAN Context Windows (Manual)`，就可以沿时间方向分段生成更长的视频。
+
+![](https://gyazo.com/43b5c2e2684957795ab7d80f8ce9976a){gyazo=image}
+
+[](/workflows/basic-workflows/scail-2/SCAIL-2_Animation_WAN-Context-Windows.json)
+
+{% mediaRow img="https://gyazo.com/55aa8d3ccee17c3a43f87f17895ebfb1 {gyazo=image}", width=33, align="left" %}
+**WAN Context Windows (Manual)**
+
+可以理解为时间轴方向的 tiling，或者 context sliding。
+
+- 将 `context_length` 设为 81 时，内部会按 81 帧为一段进行生成。
+- 如果直接这样分段，接缝会很明显，所以用 `context_overlap` 设置适当的重叠帧数。
+
+{% endmediaRow %}
+
+**输出例**
+
+![参考图像](https://gyazo.com/ce9827f452cdc3cf7d47de8b12996f28){gyazo=image} ![动作视频](https://gyazo.com/5491ba090036cbac5d76abd293d842ef){gyazo=loop} ![output](https://gyazo.com/ae5729a3c9c70711f767364534ccedf9){gyazo=loop}

--- a/src/workflows/basic-workflows/scail-2/SCAIL-2_Animation_WAN-Context-Windows.json
+++ b/src/workflows/basic-workflows/scail-2/SCAIL-2_Animation_WAN-Context-Windows.json
@@ -1,0 +1,1785 @@
+{
+  "id": "d8034549-7e0a-40f1-8c2e-de3ffc6f1cae",
+  "revision": 0,
+  "last_node_id": 124,
+  "last_link_id": 252,
+  "nodes": [
+    {
+      "id": 57,
+      "type": "CLIPVisionLoader",
+      "pos": [
+        251.28673034667955,
+        1235.5962450561526
+      ],
+      "size": [
+        270,
+        58
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP_VISION",
+          "type": "CLIP_VISION",
+          "links": [
+            106
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPVisionLoader",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "clip_vision_h.safetensors"
+      ],
+      "color": "#332922",
+      "bgcolor": "#593930"
+    },
+    {
+      "id": 38,
+      "type": "CLIPLoader",
+      "pos": [
+        56.288665771484375,
+        190.560140854834
+      ],
+      "size": [
+        301.3524169921875,
+        106
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "slot_index": 0,
+          "links": [
+            74,
+            75
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPLoader",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "umt5_xxl_fp8_e4m3fn_scaled.safetensors",
+        "wan",
+        "default"
+      ]
+    },
+    {
+      "id": 8,
+      "type": "VAEDecode",
+      "pos": [
+        1831.305390050556,
+        583.6899778882896
+      ],
+      "size": [
+        157.56002807617188,
+        46
+      ],
+      "flags": {},
+      "order": 28,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 218
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 245
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [
+            96
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAEDecode",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 7,
+      "type": "CLIPTextEncode",
+      "pos": [
+        417.8738708496094,
+        266.8154509134282
+      ],
+      "size": [
+        419.3189392089844,
+        138.8924560546875
+      ],
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 75
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            199
+          ]
+        }
+      ],
+      "title": "CLIP Text Encode (Negative Prompt)",
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走 "
+      ]
+    },
+    {
+      "id": 49,
+      "type": "VHS_VideoCombine",
+      "pos": [
+        2021.0685736443058,
+        583.6899778882896
+      ],
+      "size": [
+        372.2688903808594,
+        876.4033355712891
+      ],
+      "flags": {},
+      "order": 29,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 96
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VHS_VideoCombine",
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "a7ce59e381934733bfae03b1be029756d6ce936d"
+      },
+      "widgets_values": {
+        "frame_rate": 16,
+        "loop_count": 0,
+        "filename_prefix": "SCAIL-2",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 19,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "paused": false,
+          "params": {
+            "filename": "SCAIL-2_00025.mp4",
+            "subfolder": "",
+            "type": "output",
+            "format": "video/h264-mp4",
+            "frame_rate": 16,
+            "workflow": "SCAIL-2_00025.png",
+            "fullpath": "/home/nomax/working-linux/ComfyUI-dev/output/SCAIL-2_00025.mp4"
+          }
+        }
+      }
+    },
+    {
+      "id": 102,
+      "type": "ResizeImageMaskNode",
+      "pos": [
+        -461.91705157795747,
+        1277.5627543619055
+      ],
+      "size": [
+        270,
+        106
+      ],
+      "flags": {},
+      "order": 12,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input",
+          "type": "IMAGE,MASK",
+          "link": 204
+        }
+      ],
+      "outputs": [
+        {
+          "name": "resized",
+          "type": "IMAGE",
+          "links": [
+            203
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ResizeImageMaskNode"
+      },
+      "widgets_values": [
+        "scale total pixels",
+        0.5,
+        "nearest-exact"
+      ],
+      "color": "#233",
+      "bgcolor": "#355"
+    },
+    {
+      "id": 37,
+      "type": "UNETLoader",
+      "pos": [
+        -59.809774398803675,
+        -84.75058912563465
+      ],
+      "size": [
+        305.3782043457031,
+        82
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            183
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "UNETLoader",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "wan2.1_14B_SCAIL_2_fp8_scaled.safetensors",
+        "default"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 96,
+      "type": "LoraLoaderModelOnly",
+      "pos": [
+        276.2320190445451,
+        -84.75058912563465
+      ],
+      "size": [
+        314.38576392812183,
+        82
+      ],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 183
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            184
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoraLoaderModelOnly",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.60"
+      },
+      "widgets_values": [
+        "Wan2.1/Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors",
+        1
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 120,
+      "type": "Reroute",
+      "pos": [
+        1715.7130963493837,
+        468.5779949512076
+      ],
+      "size": [
+        75,
+        26
+      ],
+      "flags": {},
+      "order": 11,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "",
+          "type": "*",
+          "link": 244
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "VAE",
+          "links": [
+            245
+          ]
+        }
+      ],
+      "properties": {
+        "showOutputText": false,
+        "horizontal": false
+      }
+    },
+    {
+      "id": 39,
+      "type": "VAELoader",
+      "pos": [
+        525.0368322106934,
+        468.5779949512076
+      ],
+      "size": [
+        306.36004638671875,
+        58
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "slot_index": 0,
+          "links": [
+            200,
+            244
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAELoader",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "wan_2.1_vae.safetensors"
+      ],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 56,
+      "type": "CLIPVisionEncode",
+      "pos": [
+        577.9174829101565,
+        1301.870476013184
+      ],
+      "size": [
+        271.6761474609375,
+        78
+      ],
+      "flags": {},
+      "order": 22,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip_vision",
+          "type": "CLIP_VISION",
+          "link": 106
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 242
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CLIP_VISION_OUTPUT",
+          "type": "CLIP_VISION_OUTPUT",
+          "links": [
+            202
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPVisionEncode",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "none"
+      ],
+      "color": "#332922",
+      "bgcolor": "#593930"
+    },
+    {
+      "id": 58,
+      "type": "LoadImage",
+      "pos": [
+        -800.6210036236067,
+        1277.5627543619055
+      ],
+      "size": [
+        308.07680913429937,
+        543.642446368963
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            204
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "pexels-photo-31438123.jpg",
+        "image"
+      ],
+      "color": "#233",
+      "bgcolor": "#355"
+    },
+    {
+      "id": 119,
+      "type": "Reroute",
+      "pos": [
+        25.7972264472059,
+        669.0146817503652
+      ],
+      "size": [
+        75,
+        26
+      ],
+      "flags": {},
+      "order": 15,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "",
+          "type": "*",
+          "link": 239
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "IMAGE",
+          "links": [
+            240,
+            241
+          ]
+        }
+      ],
+      "properties": {
+        "showOutputText": false,
+        "horizontal": false
+      }
+    },
+    {
+      "id": 123,
+      "type": "MarkdownNote",
+      "pos": [
+        -548.6500412597653,
+        -84.75058912563465
+      ],
+      "size": [
+        461.4852607760207,
+        466.4268689388148
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "## models\n\n- checkpoints\n  - [sam3.1_multiplex_fp16.safetensors](https://huggingface.co/Comfy-Org/sam3.1/blob/main/checkpoints/sam3.1_multiplex_fp16.safetensors)\n- clip_vision\n  - [clip_vision_h.safetensors](https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/blob/main/split_files/clip_vision/clip_vision_h.safetensors)\n- diffusion_models\n  - [wan2.1_14B_SCAIL_2_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/SCAIL-2/blob/main/diffusion_models/wan2.1_14B_SCAIL_2_fp8_scaled.safetensors)\n- loras\n  - [Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors](https://huggingface.co/lightx2v/Wan2.1-I2V-14B-480P-StepDistill-CfgDistill-Lightx2v/blob/main/loras/Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors)\n- text_encoders\n  - [umt5_xxl_fp8_e4m3fn_scaled.safetensors](https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/blob/main/split_files/text_encoders/umt5_xxl_fp8_e4m3fn_scaled.safetensors)\n- vae\n  - [wan_2.1_vae.safetensors](https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/blob/main/split_files/vae/wan_2.1_vae.safetensors)\n\n```text\n📂ComfyUI/\n└── 📂models/\n    ├── 📂checkpoints/\n    │   └── sam3.1_multiplex_fp16.safetensors\n    ├── 📂clip_vision/\n    │   └── clip_vision_h.safetensors\n    ├── 📂diffusion_models/\n    │   └── wan2.1_14B_SCAIL_2_fp8_scaled.safetensors\n    ├── 📂loras/\n    │   └── Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors\n    ├── 📂text_encoders/\n    │   └── umt5_xxl_fp8_e4m3fn_scaled.safetensors\n    └── 📂vae/\n        └── wan_2.1_vae.safetensors\n```"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 103,
+      "type": "ResizeImageMaskNode",
+      "pos": [
+        -154.42166660971037,
+        1277.5627543619055
+      ],
+      "size": [
+        270,
+        106
+      ],
+      "flags": {},
+      "order": 17,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input",
+          "type": "IMAGE,MASK",
+          "link": 203
+        }
+      ],
+      "outputs": [
+        {
+          "name": "resized",
+          "type": "IMAGE",
+          "links": [
+            209,
+            212,
+            233,
+            242
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ResizeImageMaskNode"
+      },
+      "widgets_values": [
+        "scale to multiple",
+        32,
+        "nearest-exact"
+      ],
+      "color": "#233",
+      "bgcolor": "#355"
+    },
+    {
+      "id": 104,
+      "type": "GetImageSize",
+      "pos": [
+        630.4935595703129,
+        1448.041027605726
+      ],
+      "size": [
+        219.10007080078117,
+        136
+      ],
+      "flags": {},
+      "order": 20,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 212
+        }
+      ],
+      "outputs": [
+        {
+          "name": "width",
+          "type": "INT",
+          "links": [
+            213
+          ]
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "links": [
+            214
+          ]
+        },
+        {
+          "name": "batch_size",
+          "type": "INT",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "GetImageSize"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 110,
+      "type": "CheckpointLoaderSimple",
+      "pos": [
+        -472.9277129444554,
+        773.4790318695161
+      ],
+      "size": [
+        297.3094587159344,
+        98
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            223,
+            238
+          ]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [
+            220,
+            243
+          ]
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple",
+        "cnr_id": "comfy-core",
+        "ver": "0.19.3"
+      },
+      "widgets_values": [
+        "sam3.1_multiplex_fp16.safetensors"
+      ]
+    },
+    {
+      "id": 109,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -140.2924833863619,
+        847.1714690725746
+      ],
+      "size": [
+        250.42005327504967,
+        109.84222389181082
+      ],
+      "flags": {},
+      "order": 13,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 220
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            224
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode",
+        "cnr_id": "comfy-core",
+        "ver": "0.19.3"
+      },
+      "widgets_values": [
+        "human"
+      ],
+      "color": "#2a363b",
+      "bgcolor": "#3f5159"
+    },
+    {
+      "id": 115,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -140.2924833863619,
+        1068.66630403893
+      ],
+      "size": [
+        250.42005327504967,
+        109.84222389181082
+      ],
+      "flags": {},
+      "order": 14,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 243
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            232
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode",
+        "cnr_id": "comfy-core",
+        "ver": "0.19.3"
+      },
+      "widgets_values": [
+        "human"
+      ],
+      "color": "#233",
+      "bgcolor": "#355"
+    },
+    {
+      "id": 116,
+      "type": "SAM3_VideoTrack",
+      "pos": [
+        165.3271034107571,
+        1007.8240766656425
+      ],
+      "size": [
+        215.80859375,
+        166
+      ],
+      "flags": {},
+      "order": 21,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "images",
+          "name": "images",
+          "type": "IMAGE",
+          "link": 233
+        },
+        {
+          "label": "model",
+          "name": "model",
+          "type": "MODEL",
+          "link": 238
+        },
+        {
+          "label": "initial_mask",
+          "name": "initial_mask",
+          "shape": 7,
+          "type": "MASK",
+          "link": null
+        },
+        {
+          "label": "conditioning",
+          "name": "conditioning",
+          "shape": 7,
+          "type": "CONDITIONING",
+          "link": 232
+        }
+      ],
+      "outputs": [
+        {
+          "name": "track_data",
+          "type": "SAM3_TRACK_DATA",
+          "links": [
+            234
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "SAM3_VideoTrack",
+        "cnr_id": "comfy-core",
+        "ver": "0.19.3"
+      },
+      "widgets_values": [
+        0.5,
+        0,
+        1
+      ],
+      "color": "#233",
+      "bgcolor": "#355"
+    },
+    {
+      "id": 112,
+      "type": "SAM3_VideoTrack",
+      "pos": [
+        159.95932129876255,
+        754.1190318695158
+      ],
+      "size": [
+        215.80859375,
+        166
+      ],
+      "flags": {},
+      "order": 18,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "images",
+          "name": "images",
+          "type": "IMAGE",
+          "link": 240
+        },
+        {
+          "label": "model",
+          "name": "model",
+          "type": "MODEL",
+          "link": 223
+        },
+        {
+          "label": "initial_mask",
+          "name": "initial_mask",
+          "shape": 7,
+          "type": "MASK",
+          "link": null
+        },
+        {
+          "label": "conditioning",
+          "name": "conditioning",
+          "shape": 7,
+          "type": "CONDITIONING",
+          "link": 224
+        }
+      ],
+      "outputs": [
+        {
+          "name": "track_data",
+          "type": "SAM3_TRACK_DATA",
+          "links": [
+            229
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "SAM3_VideoTrack",
+        "cnr_id": "comfy-core",
+        "ver": "0.19.3"
+      },
+      "widgets_values": [
+        0.5,
+        0,
+        1
+      ],
+      "color": "#2a363b",
+      "bgcolor": "#3f5159"
+    },
+    {
+      "id": 107,
+      "type": "SCAIL2ColoredMask",
+      "pos": [
+        506.50542810498916,
+        905.2770955134855
+      ],
+      "size": [
+        339.45703125,
+        126
+      ],
+      "flags": {},
+      "order": 23,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "driving_track_data",
+          "type": "SAM3_TRACK_DATA",
+          "link": 229
+        },
+        {
+          "name": "ref_track_data",
+          "shape": 7,
+          "type": "SAM3_TRACK_DATA",
+          "link": 234
+        }
+      ],
+      "outputs": [
+        {
+          "name": "pose_video_mask",
+          "type": "IMAGE",
+          "links": [
+            230,
+            236
+          ]
+        },
+        {
+          "name": "reference_image_mask",
+          "type": "IMAGE",
+          "links": [
+            231,
+            250
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "SCAIL2ColoredMask"
+      },
+      "widgets_values": [
+        "",
+        "area",
+        false
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 117,
+      "type": "PreviewImage",
+      "pos": [
+        1287.634225650107,
+        1137.316846620137
+      ],
+      "size": [
+        210,
+        258
+      ],
+      "flags": {},
+      "order": 26,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 250
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "Node name for S&R": "PreviewImage"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 6,
+      "type": "CLIPTextEncode",
+      "pos": [
+        417.9232177734375,
+        63.8154509134279
+      ],
+      "size": [
+        419.26959228515625,
+        148.8194122314453
+      ],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 74
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            198
+          ]
+        }
+      ],
+      "title": "CLIP Text Encode (Positive Prompt)",
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "A short-haired man wearing a striped shirt, hands on his hips, touching his hair.full body"
+      ]
+    },
+    {
+      "id": 118,
+      "type": "PreviewImage",
+      "pos": [
+        1041.5040075988006,
+        1137.316846620137
+      ],
+      "size": [
+        210,
+        258
+      ],
+      "flags": {},
+      "order": 24,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 236
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "Node name for S&R": "PreviewImage"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 101,
+      "type": "WanSCAILToVideo",
+      "pos": [
+        1082.8079278436192,
+        604.0725314640773
+      ],
+      "size": [
+        344.02734375,
+        434
+      ],
+      "flags": {},
+      "order": 25,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 198
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 199
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 200
+        },
+        {
+          "name": "pose_video",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": 241
+        },
+        {
+          "name": "pose_video_mask",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": 230
+        },
+        {
+          "name": "reference_image",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": 209
+        },
+        {
+          "name": "reference_image_mask",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": 231
+        },
+        {
+          "name": "clip_vision_output",
+          "shape": 7,
+          "type": "CLIP_VISION_OUTPUT",
+          "link": 202
+        },
+        {
+          "name": "previous_frames",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "width",
+          "type": "INT",
+          "widget": {
+            "name": "width"
+          },
+          "link": 213
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "widget": {
+            "name": "height"
+          },
+          "link": 214
+        }
+      ],
+      "outputs": [
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "links": [
+            215
+          ]
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "links": [
+            216
+          ]
+        },
+        {
+          "name": "latent",
+          "type": "LATENT",
+          "links": [
+            217
+          ]
+        },
+        {
+          "name": "video_frame_offset",
+          "type": "INT",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "WanSCAILToVideo"
+      },
+      "widgets_values": [
+        512,
+        896,
+        133,
+        1,
+        1,
+        0,
+        1,
+        0,
+        5,
+        false
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 113,
+      "type": "VHS_LoadVideo",
+      "pos": [
+        -800.6210036236067,
+        455.00750561396774
+      ],
+      "size": [
+        261.6533203125,
+        753.272357822205
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            239
+          ]
+        },
+        {
+          "name": "frame_count",
+          "type": "INT",
+          "links": null
+        },
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "links": null
+        },
+        {
+          "name": "video_info",
+          "type": "VHS_VIDEOINFO",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VHS_LoadVideo",
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "2984ec4c4b93292421888f38db74a5e8802a8ff8"
+      },
+      "widgets_values": {
+        "video": "14637751_2160_3840_30fps.mp4",
+        "force_rate": 16,
+        "custom_width": 0,
+        "custom_height": 0,
+        "frame_load_cap": 133,
+        "skip_first_frames": 0,
+        "select_every_nth": 1,
+        "format": "None",
+        "videopreview": {
+          "hidden": false,
+          "paused": false,
+          "params": {
+            "filename": "14637751_2160_3840_30fps.mp4",
+            "type": "input",
+            "format": "video/mp4",
+            "force_rate": 16,
+            "custom_width": 0,
+            "custom_height": 0,
+            "frame_load_cap": 133,
+            "skip_first_frames": 0,
+            "select_every_nth": 1
+          }
+        }
+      },
+      "color": "#2a363b",
+      "bgcolor": "#3f5159"
+    },
+    {
+      "id": 3,
+      "type": "KSampler",
+      "pos": [
+        1475.7130963493837,
+        583.6899778882896
+      ],
+      "size": [
+        315,
+        262
+      ],
+      "flags": {},
+      "order": 27,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 252
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 215
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 216
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 217
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "slot_index": 0,
+          "links": [
+            218
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "KSampler",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        123456,
+        "fixed",
+        6,
+        1,
+        "euler",
+        "simple",
+        1
+      ]
+    },
+    {
+      "id": 48,
+      "type": "ModelSamplingSD3",
+      "pos": [
+        621.2813720703125,
+        -84.75058912563465
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {},
+      "order": 16,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 184
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            251
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ModelSamplingSD3",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        5
+      ]
+    },
+    {
+      "id": 124,
+      "type": "WanContextWindowsManual",
+      "pos": [
+        921.0647655256324,
+        -84.75058912563465
+      ],
+      "size": [
+        316.1412109375,
+        202
+      ],
+      "flags": {},
+      "order": 19,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 251
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            252
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "WanContextWindowsManual"
+      },
+      "widgets_values": [
+        81,
+        29,
+        "standard_static",
+        1,
+        false,
+        "pyramid",
+        true
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    }
+  ],
+  "links": [
+    [
+      74,
+      38,
+      0,
+      6,
+      0,
+      "CLIP"
+    ],
+    [
+      75,
+      38,
+      0,
+      7,
+      0,
+      "CLIP"
+    ],
+    [
+      96,
+      8,
+      0,
+      49,
+      0,
+      "IMAGE"
+    ],
+    [
+      106,
+      57,
+      0,
+      56,
+      0,
+      "CLIP_VISION"
+    ],
+    [
+      183,
+      37,
+      0,
+      96,
+      0,
+      "MODEL"
+    ],
+    [
+      184,
+      96,
+      0,
+      48,
+      0,
+      "MODEL"
+    ],
+    [
+      198,
+      6,
+      0,
+      101,
+      0,
+      "CONDITIONING"
+    ],
+    [
+      199,
+      7,
+      0,
+      101,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      200,
+      39,
+      0,
+      101,
+      2,
+      "VAE"
+    ],
+    [
+      202,
+      56,
+      0,
+      101,
+      7,
+      "CLIP_VISION_OUTPUT"
+    ],
+    [
+      203,
+      102,
+      0,
+      103,
+      0,
+      "IMAGE"
+    ],
+    [
+      204,
+      58,
+      0,
+      102,
+      0,
+      "IMAGE"
+    ],
+    [
+      209,
+      103,
+      0,
+      101,
+      5,
+      "IMAGE"
+    ],
+    [
+      212,
+      103,
+      0,
+      104,
+      0,
+      "IMAGE"
+    ],
+    [
+      213,
+      104,
+      0,
+      101,
+      9,
+      "INT"
+    ],
+    [
+      214,
+      104,
+      1,
+      101,
+      10,
+      "INT"
+    ],
+    [
+      215,
+      101,
+      0,
+      3,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      216,
+      101,
+      1,
+      3,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      217,
+      101,
+      2,
+      3,
+      3,
+      "LATENT"
+    ],
+    [
+      218,
+      3,
+      0,
+      8,
+      0,
+      "LATENT"
+    ],
+    [
+      220,
+      110,
+      1,
+      109,
+      0,
+      "CLIP"
+    ],
+    [
+      223,
+      110,
+      0,
+      112,
+      1,
+      "MODEL"
+    ],
+    [
+      224,
+      109,
+      0,
+      112,
+      3,
+      "CONDITIONING"
+    ],
+    [
+      229,
+      112,
+      0,
+      107,
+      0,
+      "SAM3_TRACK_DATA"
+    ],
+    [
+      230,
+      107,
+      0,
+      101,
+      4,
+      "IMAGE"
+    ],
+    [
+      231,
+      107,
+      1,
+      101,
+      6,
+      "IMAGE"
+    ],
+    [
+      232,
+      115,
+      0,
+      116,
+      3,
+      "CONDITIONING"
+    ],
+    [
+      233,
+      103,
+      0,
+      116,
+      0,
+      "IMAGE"
+    ],
+    [
+      234,
+      116,
+      0,
+      107,
+      1,
+      "SAM3_TRACK_DATA"
+    ],
+    [
+      236,
+      107,
+      0,
+      118,
+      0,
+      "IMAGE"
+    ],
+    [
+      238,
+      110,
+      0,
+      116,
+      1,
+      "MODEL"
+    ],
+    [
+      239,
+      113,
+      0,
+      119,
+      0,
+      "IMAGE"
+    ],
+    [
+      240,
+      119,
+      0,
+      112,
+      0,
+      "IMAGE"
+    ],
+    [
+      241,
+      119,
+      0,
+      101,
+      3,
+      "IMAGE"
+    ],
+    [
+      242,
+      103,
+      0,
+      56,
+      1,
+      "IMAGE"
+    ],
+    [
+      243,
+      110,
+      1,
+      115,
+      0,
+      "CLIP"
+    ],
+    [
+      244,
+      39,
+      0,
+      120,
+      0,
+      "VAE"
+    ],
+    [
+      245,
+      120,
+      0,
+      8,
+      1,
+      "VAE"
+    ],
+    [
+      250,
+      107,
+      1,
+      117,
+      0,
+      "IMAGE"
+    ],
+    [
+      251,
+      48,
+      0,
+      124,
+      0,
+      "MODEL"
+    ],
+    [
+      252,
+      124,
+      0,
+      3,
+      0,
+      "MODEL"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.5644739300537773,
+      "offset": [
+        420.4411568691918,
+        395.94500319536957
+      ]
+    },
+    "frontendVersion": "1.45.15",
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true
+  },
+  "version": 0.4
+}


### PR DESCRIPTION
## Summary

- Add a SCAIL-2 animation workflow using `WAN Context Windows (Manual)` for videos over 81 frames.
- Add the 81+ frame section to the Japanese, English, and Chinese SCAIL-2 pages.
- Sync the updated Gyazo screenshots across the localized pages.

## Checks

- `git diff --check`
- `python3 -m json.tool src/workflows/basic-workflows/scail-2/SCAIL-2_Animation_WAN-Context-Windows.json`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation across multiple languages with refreshed examples and visual assets
  * Added new section on extended-length animation generation (81+ frames) with configuration guidelines

* **New Features**
  * Added workflow example for advanced animation generation using context windows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->