### PR TITLE
Add Ideogram TurboTime and SCAIL-2 notes

### DIFF
--- a/src/content/en/basic-workflows/ideogram-4.md
+++ b/src/content/en/basic-workflows/ideogram-4.md
@@ -169,7 +169,7 @@ This is a LoRA published by Ostris for generating in 2 to 8 steps.
 
 ### text2image (8 step)
 
-![](https://gyazo.com/1bd65d1d1c703d8890df1f68cc424e35){gyazo=image}
+![](https://gyazo.com/f75015885dc02060128725d779ce7d49){gyazo=image}
 
 [](/workflows/basic-workflows/ideogram-4/Ideogram_4.0_text2image_turbotime.json)
 

--- a/src/content/en/basic-workflows/ideogram-4.md
+++ b/src/content/en/basic-workflows/ideogram-4.md
@@ -6,7 +6,7 @@ slug: ideogram-4
 navId: ideogram-4
 title: "Ideogram 4.0"
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-18
 summary: "Image generation with Ideogram 4.0"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:
@@ -148,6 +148,34 @@ Ideogram 4.0 loads two diffusion models for its slightly unusual CFG.
 - It is easy to wonder what the difference is, but you can think of it as a trick for handling the positive prompt more delicately.
 
 {% endmediaRow %}
+
+---
+
+## Ideogram 4 TurboTime LoRA
+
+This is a LoRA published by Ostris for generating in 2 to 8 steps.
+
+### Model Download
+
+- loras
+  - [ideogram_4_turbotime_v1.safetensors](https://huggingface.co/ostris/ideogram_4_turbotime_lora/blob/main/ideogram_4_turbotime_v1.safetensors) (847 MB)
+
+```text
+📂ComfyUI/
+└── 📂models/
+    └── 📂loras/
+        └── ideogram_4_turbotime_v1.safetensors
+```
+
+### text2image (8 step)
+
+![](https://gyazo.com/1bd65d1d1c703d8890df1f68cc424e35){gyazo=image}
+
+[](/workflows/basic-workflows/ideogram-4/Ideogram_4.0_text2image_turbotime.json)
+
+- It generates with CFG 1.0, so the unconditional model is no longer needed.
+- It is described as a 2 to 8 step LoRA, but very low step counts clearly start to break the image.
+- For now, using it at 8 steps is a good choice.
 
 {% mediaRow img="https://gyazo.com/26ef78ed5bf868ab5ca9a62b643640ff {gyazo=image}", width=33, align="left" %}
 **CFG**

--- a/src/content/en/basic-workflows/scail-2.md
+++ b/src/content/en/basic-workflows/scail-2.md
@@ -6,7 +6,7 @@ slug: scail-2
 navId: scail-2
 title: "SCAIL-2"
 created: 2026-06-11
-updated: 2026-06-11
+updated: 2026-06-18
 summary: "Transfer video motion to the person in a reference image with SCAIL-2"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:
@@ -200,6 +200,39 @@ When there are multiple people, it becomes important to control which person sho
 **Output Example**
 
 ![reference image](https://gyazo.com/567acaf722ca9e839ec7cb834c1ed344){gyazo=image} ![motion video](https://gyazo.com/53461ca17746349fbd11e69798460ea6){gyazo=loop} ![output](https://gyazo.com/913ff446dd39fa33f56ba9ed07ce6e16){gyazo=loop}
+
+---
+
+## Animation Mode (Multiple References)
+
+You can also provide several reference images at once, such as another angle of the same person or a separate background image.
+
+![](https://gyazo.com/a135dfdaef80d8d16acd904f3d26a12a){gyazo=image}
+
+[](/workflows/basic-workflows/scail-2/SCAIL-2_Animation_multi-ref.json)
+
+The basic flow is the same as the normal Animation mode. The difference is that the reference images are passed in as a batch instead of a single image.
+
+{% mediaRow img="https://gyazo.com/23f0af93cd4027f7a8366c16b62181e0 {gyazo=image}", width=33, align="left" %}
+**Batch input**
+
+Input the images you want to reference into `Batch Images`.
+
+- Once the images are batched, they are all cropped to the same size as the first image.
+  - Images after the first one usually do not need to be resized, but anything outside that size will not be reflected.
+  - In this workflow, the later images are padded to match the first image size.
+- The **last** input image is reflected most strongly.
+  - It seems better to place the person you want to move after the background.
+
+{% endmediaRow %}
+
+Multiple reference images can be used, but this does not automatically adjust the background to the person's size or rewrite the whole image into a natural composition.
+
+Honestly, in many cases it is better to first create a single polished reference image with image editing.
+
+**Output Example**
+
+![reference image 1](https://gyazo.com/d2935f1c3b0ff3016616c54d88d6be56){gyazo=image} ![reference image 2](https://gyazo.com/7819645aea776b0aa5e24e8d9f642487){gyazo=image} ![reference image 3](https://gyazo.com/4617d933cec4a3431d36af11c65180e3){gyazo=image} ![motion video](https://gyazo.com/5491ba090036cbac5d76abd293d842ef){gyazo=loop} ![output](https://gyazo.com/50154740248550b3ffa1dfee024da941){gyazo=loop}
 
 ---
 

--- a/src/content/en/basic-workflows/scail-2.md
+++ b/src/content/en/basic-workflows/scail-2.md
@@ -33,17 +33,17 @@ Rather than humans building a complicated processing pipeline by hand, it is oft
 ## Model Download
 
 - checkpoints
-  - [sam3.1_multiplex_fp16.safetensors](https://huggingface.co/Comfy-Org/sam3.1/blob/main/checkpoints/sam3.1_multiplex_fp16.safetensors)
+  - [sam3.1_multiplex_fp16.safetensors](https://huggingface.co/Comfy-Org/sam3.1/blob/main/checkpoints/sam3.1_multiplex_fp16.safetensors) (1.75 GB)
 - clip_vision
-  - [clip_vision_h.safetensors](https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/blob/main/split_files/clip_vision/clip_vision_h.safetensors)
+  - [clip_vision_h.safetensors](https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/blob/main/split_files/clip_vision/clip_vision_h.safetensors) (1.26 GB)
 - diffusion_models
-  - [wan2.1_14B_SCAIL_2_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/SCAIL-2/blob/main/diffusion_models/wan2.1_14B_SCAIL_2_fp8_scaled.safetensors)
+  - [wan2.1_14B_SCAIL_2_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/SCAIL-2/blob/main/diffusion_models/wan2.1_14B_SCAIL_2_fp8_scaled.safetensors) (17.7 GB)
 - loras
-  - [Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors](https://huggingface.co/lightx2v/Wan2.1-I2V-14B-480P-StepDistill-CfgDistill-Lightx2v/blob/main/loras/Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors)
+  - [Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors](https://huggingface.co/lightx2v/Wan2.1-I2V-14B-480P-StepDistill-CfgDistill-Lightx2v/blob/main/loras/Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors) (739 MB)
 - text_encoders
-  - [umt5_xxl_fp8_e4m3fn_scaled.safetensors](https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/blob/main/split_files/text_encoders/umt5_xxl_fp8_e4m3fn_scaled.safetensors)
+  - [umt5_xxl_fp8_e4m3fn_scaled.safetensors](https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/blob/main/split_files/text_encoders/umt5_xxl_fp8_e4m3fn_scaled.safetensors) (6.74 GB)
 - vae
-  - [wan_2.1_vae.safetensors](https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/blob/main/split_files/vae/wan_2.1_vae.safetensors)
+  - [wan_2.1_vae.safetensors](https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/blob/main/split_files/vae/wan_2.1_vae.safetensors) (254 MB)
 
 ```text
 📂ComfyUI/

--- a/src/content/ja/basic-workflows/ideogram-4.md
+++ b/src/content/ja/basic-workflows/ideogram-4.md
@@ -182,7 +182,7 @@ Ostris さんが公開している、2〜8 step で生成できる LoRA です�
 
 ### text2image (8 step)
 
-![](https://gyazo.com/1bd65d1d1c703d8890df1f68cc424e35){gyazo=image}
+![](https://gyazo.com/f75015885dc02060128725d779ce7d49){gyazo=image}
 
 [](/workflows/basic-workflows/ideogram-4/Ideogram_4.0_text2image_turbotime.json)
 

--- a/src/content/ja/basic-workflows/ideogram-4.md
+++ b/src/content/ja/basic-workflows/ideogram-4.md
@@ -6,7 +6,7 @@ slug: ideogram-4
 navId: ideogram-4
 title: "Ideogram 4.0"
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-18
 summary: "Ideogram 4.0での画像生成"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:
@@ -161,3 +161,30 @@ Ideogram 4.0 では、少し特殊な CFG のために diffusion model を 2 つ
 - この workflow では、全体の 70% 以降は cfg が 3 になります。
 
 {% endmediaRow %}
+
+---
+
+## Ideogram 4 TurboTime LoRA
+
+Ostris さんが公開している、2〜8 step で生成できる LoRA です。
+
+### モデルのダウンロード
+
+- loras
+  - [ideogram_4_turbotime_v1.safetensors](https://huggingface.co/ostris/ideogram_4_turbotime_lora/blob/main/ideogram_4_turbotime_v1.safetensors) (847 MB)
+
+```text
+📂ComfyUI/
+└── 📂models/
+    └── 📂loras/
+        └── ideogram_4_turbotime_v1.safetensors
+```
+
+### text2image (8 step)
+
+![](https://gyazo.com/1bd65d1d1c703d8890df1f68cc424e35){gyazo=image}
+
+[](/workflows/basic-workflows/ideogram-4/Ideogram_4.0_text2image_turbotime.json)
+
+- CFG 1.0 で生成するため、unconditional model は不要になります。
+- 2〜8 step 用とされていますが、step 数が少なすぎると明確に崩れ始めるので、現状は 8 step で使うのがいいでしょう。

--- a/src/content/ja/basic-workflows/scail-2.md
+++ b/src/content/ja/basic-workflows/scail-2.md
@@ -33,17 +33,17 @@ ViTPose や OpenPose で棒人間を作り、それを条件として人物を�
 ## モデルのダウンロード
 
 - checkpoints
-  - [sam3.1_multiplex_fp16.safetensors](https://huggingface.co/Comfy-Org/sam3.1/blob/main/checkpoints/sam3.1_multiplex_fp16.safetensors)
+  - [sam3.1_multiplex_fp16.safetensors](https://huggingface.co/Comfy-Org/sam3.1/blob/main/checkpoints/sam3.1_multiplex_fp16.safetensors) (1.75 GB)
 - clip_vision
-  - [clip_vision_h.safetensors](https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/blob/main/split_files/clip_vision/clip_vision_h.safetensors)
+  - [clip_vision_h.safetensors](https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/blob/main/split_files/clip_vision/clip_vision_h.safetensors) (1.26 GB)
 - diffusion_models
-  - [wan2.1_14B_SCAIL_2_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/SCAIL-2/blob/main/diffusion_models/wan2.1_14B_SCAIL_2_fp8_scaled.safetensors)
+  - [wan2.1_14B_SCAIL_2_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/SCAIL-2/blob/main/diffusion_models/wan2.1_14B_SCAIL_2_fp8_scaled.safetensors) (17.7 GB)
 - loras
-  - [Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors](https://huggingface.co/lightx2v/Wan2.1-I2V-14B-480P-StepDistill-CfgDistill-Lightx2v/blob/main/loras/Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors)
+  - [Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors](https://huggingface.co/lightx2v/Wan2.1-I2V-14B-480P-StepDistill-CfgDistill-Lightx2v/blob/main/loras/Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors) (739 MB)
 - text_encoders
-  - [umt5_xxl_fp8_e4m3fn_scaled.safetensors](https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/blob/main/split_files/text_encoders/umt5_xxl_fp8_e4m3fn_scaled.safetensors)
+  - [umt5_xxl_fp8_e4m3fn_scaled.safetensors](https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/blob/main/split_files/text_encoders/umt5_xxl_fp8_e4m3fn_scaled.safetensors) (6.74 GB)
 - vae
-  - [wan_2.1_vae.safetensors](https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/blob/main/split_files/vae/wan_2.1_vae.safetensors)
+  - [wan_2.1_vae.safetensors](https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/blob/main/split_files/vae/wan_2.1_vae.safetensors) (254 MB)
 
 ```text
 📂ComfyUI/

--- a/src/content/ja/basic-workflows/scail-2.md
+++ b/src/content/ja/basic-workflows/scail-2.md
@@ -6,7 +6,7 @@ slug: scail-2
 navId: scail-2
 title: "SCAIL-2"
 created: 2026-06-11
-updated: 2026-06-11
+updated: 2026-06-18
 summary: "SCAIL-2で参照画像の人物に動画の動きを転送する"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:
@@ -200,6 +200,39 @@ SCAIL-2 は複数人の動画・画像にも対応しています。
 **出力例**
 
 ![参照画像](https://gyazo.com/567acaf722ca9e839ec7cb834c1ed344){gyazo=image} ![モーション用動画](https://gyazo.com/53461ca17746349fbd11e69798460ea6){gyazo=loop} ![output](https://gyazo.com/913ff446dd39fa33f56ba9ed07ce6e16){gyazo=loop}
+
+---
+
+## Animation モード (マルチ参照)
+
+参照人物の別角度の画像や、背景用の画像をまとめて参照させることもできます。
+
+![](https://gyazo.com/a135dfdaef80d8d16acd904f3d26a12a){gyazo=image}
+
+[](/workflows/basic-workflows/scail-2/SCAIL-2_Animation_multi-ref.json)
+
+基本的な流れは通常の Animation モードと同じです。違いは、参照画像を 1 枚ではなくバッチとして入力する点です。
+
+{% mediaRow img="https://gyazo.com/23f0af93cd4027f7a8366c16b62181e0 {gyazo=image}", width=33, align="left" %}
+**バッチ入力**
+
+参照させたい画像を `Batch Images` に入力します。
+
+- バッチにした時点で、すべて 1 枚目と同じサイズにクロップされます。
+  - 2 枚目以降は基本的にリサイズしなくても構いませんが、はみ出した部分は反映されません。
+  - この workflow では、1 枚目と同じサイズになるように padding しています。
+- **一番最後** に入力した画像が最も強く反映されます。
+  - 背景よりも、動かしたい人物を後ろに入れるほうがよさそうです。
+
+{% endmediaRow %}
+
+複数の参照画像は使えますが、人物のサイズに合わせて背景を調整したり、全体を自然にリライトしたりするわけではありません。
+
+正直なところ、この機能を使うより、画像編集で先に参照画像を 1 枚作り込んだほうがよいでしょう。
+
+**出力例**
+
+![参照画像1](https://gyazo.com/d2935f1c3b0ff3016616c54d88d6be56){gyazo=image} ![参照画像2](https://gyazo.com/7819645aea776b0aa5e24e8d9f642487){gyazo=image} ![参照画像3](https://gyazo.com/4617d933cec4a3431d36af11c65180e3){gyazo=image} ![モーション用動画](https://gyazo.com/5491ba090036cbac5d76abd293d842ef){gyazo=loop} ![output](https://gyazo.com/50154740248550b3ffa1dfee024da941){gyazo=loop}
 
 ---
 

--- a/src/content/zh/basic-workflows/ideogram-4.md
+++ b/src/content/zh/basic-workflows/ideogram-4.md
@@ -169,7 +169,7 @@ Ideogram 4.0 为了稍微特殊的 CFG，会读取两个 diffusion model。
 
 ### text2image (8 step)
 
-![](https://gyazo.com/1bd65d1d1c703d8890df1f68cc424e35){gyazo=image}
+![](https://gyazo.com/f75015885dc02060128725d779ce7d49){gyazo=image}
 
 [](/workflows/basic-workflows/ideogram-4/Ideogram_4.0_text2image_turbotime.json)
 

--- a/src/content/zh/basic-workflows/ideogram-4.md
+++ b/src/content/zh/basic-workflows/ideogram-4.md
@@ -6,7 +6,7 @@ slug: ideogram-4
 navId: ideogram-4
 title: "Ideogram 4.0"
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-18
 summary: "使用 Ideogram 4.0 进行图像生成"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:
@@ -148,6 +148,34 @@ Ideogram 4.0 为了稍微特殊的 CFG，会读取两个 diffusion model。
 - 乍看可能会觉得这有什么区别，但可以把它理解成一种更细致处理 positive prompt 的办法。
 
 {% endmediaRow %}
+
+---
+
+## Ideogram 4 TurboTime LoRA
+
+这是 Ostris 发布的 LoRA，可以用于 2〜8 step 生成。
+
+### 模型下载
+
+- loras
+  - [ideogram_4_turbotime_v1.safetensors](https://huggingface.co/ostris/ideogram_4_turbotime_lora/blob/main/ideogram_4_turbotime_v1.safetensors) (847 MB)
+
+```text
+📂ComfyUI/
+└── 📂models/
+    └── 📂loras/
+        └── ideogram_4_turbotime_v1.safetensors
+```
+
+### text2image (8 step)
+
+![](https://gyazo.com/1bd65d1d1c703d8890df1f68cc424e35){gyazo=image}
+
+[](/workflows/basic-workflows/ideogram-4/Ideogram_4.0_text2image_turbotime.json)
+
+- 由于使用 CFG 1.0 生成，因此不需要 unconditional model。
+- 虽然它标注为 2〜8 step 用 LoRA，但 step 数太少时，图像会明显开始崩。
+- 目前建议以 8 step 使用。
 
 {% mediaRow img="https://gyazo.com/26ef78ed5bf868ab5ca9a62b643640ff {gyazo=image}", width=33, align="left" %}
 **CFG**

--- a/src/content/zh/basic-workflows/scail-2.md
+++ b/src/content/zh/basic-workflows/scail-2.md
@@ -6,7 +6,7 @@ slug: scail-2
 navId: scail-2
 title: "SCAIL-2"
 created: 2026-06-11
-updated: 2026-06-11
+updated: 2026-06-18
 summary: "使用 SCAIL-2 将视频动作转移到参考图像中的人物"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:
@@ -200,6 +200,39 @@ SCAIL-2 也支持多人视频和图像。
 **输出例**
 
 ![参考图像](https://gyazo.com/567acaf722ca9e839ec7cb834c1ed344){gyazo=image} ![动作视频](https://gyazo.com/53461ca17746349fbd11e69798460ea6){gyazo=loop} ![output](https://gyazo.com/913ff446dd39fa33f56ba9ed07ce6e16){gyazo=loop}
+
+---
+
+## Animation 模式（多参考图像）
+
+也可以一次参考多张图像，例如参考人物的其他角度图，或单独准备的背景图。
+
+![](https://gyazo.com/a135dfdaef80d8d16acd904f3d26a12a){gyazo=image}
+
+[](/workflows/basic-workflows/scail-2/SCAIL-2_Animation_multi-ref.json)
+
+基本流程和普通的 Animation 模式相同。区别在于，这里不是输入 1 张参考图像，而是以 batch 的形式输入多张参考图像。
+
+{% mediaRow img="https://gyazo.com/23f0af93cd4027f7a8366c16b62181e0 {gyazo=image}", width=33, align="left" %}
+**Batch 输入**
+
+将想要参考的图像输入到 `Batch Images`。
+
+- 形成 batch 后，所有图像都会被裁剪成和第 1 张相同的尺寸。
+  - 第 2 张之后通常不需要重新 resize，但超出这个尺寸的部分不会被反映出来。
+  - 在这个 workflow 中，会用 padding 让后面的图像匹配第 1 张的尺寸。
+- **最后** 输入的图像会被反映得最强。
+  - 比起背景，最好把想要动起来的人物放在更后面。
+
+{% endmediaRow %}
+
+虽然可以使用多张参考图像，但它并不会根据人物大小自动调整背景，也不会把整体自然地重新改写成一张图。
+
+老实说，很多情况下不如先用图像编辑做出 1 张完整的参考图像。
+
+**输出例**
+
+![参考图像 1](https://gyazo.com/d2935f1c3b0ff3016616c54d88d6be56){gyazo=image} ![参考图像 2](https://gyazo.com/7819645aea776b0aa5e24e8d9f642487){gyazo=image} ![参考图像 3](https://gyazo.com/4617d933cec4a3431d36af11c65180e3){gyazo=image} ![动作视频](https://gyazo.com/5491ba090036cbac5d76abd293d842ef){gyazo=loop} ![output](https://gyazo.com/50154740248550b3ffa1dfee024da941){gyazo=loop}
 
 ---
 

--- a/src/content/zh/basic-workflows/scail-2.md
+++ b/src/content/zh/basic-workflows/scail-2.md
@@ -33,17 +33,17 @@ tags: ["human-motion-transfer","video-generation"]
 ## 模型下载
 
 - checkpoints
-  - [sam3.1_multiplex_fp16.safetensors](https://huggingface.co/Comfy-Org/sam3.1/blob/main/checkpoints/sam3.1_multiplex_fp16.safetensors)
+  - [sam3.1_multiplex_fp16.safetensors](https://huggingface.co/Comfy-Org/sam3.1/blob/main/checkpoints/sam3.1_multiplex_fp16.safetensors) (1.75 GB)
 - clip_vision
-  - [clip_vision_h.safetensors](https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/blob/main/split_files/clip_vision/clip_vision_h.safetensors)
+  - [clip_vision_h.safetensors](https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/blob/main/split_files/clip_vision/clip_vision_h.safetensors) (1.26 GB)
 - diffusion_models
-  - [wan2.1_14B_SCAIL_2_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/SCAIL-2/blob/main/diffusion_models/wan2.1_14B_SCAIL_2_fp8_scaled.safetensors)
+  - [wan2.1_14B_SCAIL_2_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/SCAIL-2/blob/main/diffusion_models/wan2.1_14B_SCAIL_2_fp8_scaled.safetensors) (17.7 GB)
 - loras
-  - [Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors](https://huggingface.co/lightx2v/Wan2.1-I2V-14B-480P-StepDistill-CfgDistill-Lightx2v/blob/main/loras/Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors)
+  - [Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors](https://huggingface.co/lightx2v/Wan2.1-I2V-14B-480P-StepDistill-CfgDistill-Lightx2v/blob/main/loras/Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors) (739 MB)
 - text_encoders
-  - [umt5_xxl_fp8_e4m3fn_scaled.safetensors](https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/blob/main/split_files/text_encoders/umt5_xxl_fp8_e4m3fn_scaled.safetensors)
+  - [umt5_xxl_fp8_e4m3fn_scaled.safetensors](https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/blob/main/split_files/text_encoders/umt5_xxl_fp8_e4m3fn_scaled.safetensors) (6.74 GB)
 - vae
-  - [wan_2.1_vae.safetensors](https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/blob/main/split_files/vae/wan_2.1_vae.safetensors)
+  - [wan_2.1_vae.safetensors](https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/blob/main/split_files/vae/wan_2.1_vae.safetensors) (254 MB)
 
 ```text
 📂ComfyUI/

--- a/src/workflows/basic-workflows/ideogram-4/Ideogram_4.0_text2image_turbotime.json
+++ b/src/workflows/basic-workflows/ideogram-4/Ideogram_4.0_text2image_turbotime.json
@@ -557,44 +557,6 @@
       ]
     },
     {
-      "id": 111,
-      "type": "LoraLoaderModelOnly",
-      "pos": [
-        249.4552739659035,
-        -49.16835585157703
-      ],
-      "size": [
-        270,
-        82
-      ],
-      "flags": {},
-      "order": 10,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "model",
-          "type": "MODEL",
-          "link": 177
-        }
-      ],
-      "outputs": [
-        {
-          "name": "MODEL",
-          "type": "MODEL",
-          "links": [
-            178
-          ]
-        }
-      ],
-      "properties": {
-        "Node name for S&R": "LoraLoaderModelOnly"
-      },
-      "widgets_values": [
-        "ideogram_4_turbotime_v1.safetensors",
-        0.6
-      ]
-    },
-    {
       "id": 95,
       "type": "Ideogram4Scheduler",
       "pos": [
@@ -665,6 +627,46 @@
       "properties": {},
       "widgets_values": [
         "## models\n\n- diffusion_models\n  - [ideogram4_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/diffusion_models/ideogram4_fp8_scaled.safetensors) (9.28 GB)\n  - [ideogram4_nvfp4_mixed.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/diffusion_models/ideogram4_nvfp4_mixed.safetensors) (5.49 GB)\n- loras\n  - [ideogram_4_turbotime_v1.safetensors](https://huggingface.co/ostris/ideogram_4_turbotime_lora/blob/main/ideogram_4_turbotime_v1.safetensors) (847 MB)\n- text_encoders\n  - [qwen3vl_8b_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/text_encoders/qwen3vl_8b_fp8_scaled.safetensors) (10.6 GB)\n- vae\n  - [flux2-vae.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/vae/flux2-vae.safetensors) (336 MB)\n\n```text\n📂ComfyUI/\n└── 📂models/\n    ├── 📂diffusion_models/\n    │   ├── ideogram4_fp8_scaled.safetensors\n    │   └── ideogram4_nvfp4_mixed.safetensors\n    ├── 📂loras/\n    │   └── ideogram_4_turbotime_v1.safetensors\n    ├── 📂text_encoders/\n    │   └── qwen3vl_8b_fp8_scaled.safetensors\n    └── 📂vae/\n         └── flux2-vae.safetensors\n```"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 111,
+      "type": "LoraLoaderModelOnly",
+      "pos": [
+        247.84471481703875,
+        -50.778860936690556
+      ],
+      "size": [
+        270,
+        82
+      ],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 177
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            178
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": [
+        "ideogram_4_turbotime_v1.safetensors",
+        0.6
       ],
       "color": "#323",
       "bgcolor": "#535"

--- a/src/workflows/basic-workflows/ideogram-4/Ideogram_4.0_text2image_turbotime.json
+++ b/src/workflows/basic-workflows/ideogram-4/Ideogram_4.0_text2image_turbotime.json
@@ -1,0 +1,836 @@
+{
+  "id": "d8034549-7e0a-40f1-8c2e-de3ffc6f1cae",
+  "revision": 0,
+  "last_node_id": 112,
+  "last_link_id": 181,
+  "nodes": [
+    {
+      "id": 76,
+      "type": "KSamplerSelect",
+      "pos": [
+        560.1252292712549,
+        324.6528974302894
+      ],
+      "size": [
+        270,
+        68.88020833333334
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "SAMPLER",
+          "type": "SAMPLER",
+          "links": [
+            132
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "KSamplerSelect",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.56",
+        "enableTabs": false,
+        "tabWidth": 65,
+        "tabXOffset": 10,
+        "hasSecondTab": false,
+        "secondTabText": "Send Back",
+        "secondTabOffset": 80,
+        "secondTabWidth": 65
+      },
+      "widgets_values": [
+        "euler"
+      ]
+    },
+    {
+      "id": 8,
+      "type": "VAEDecode",
+      "pos": [
+        1180.6146240234375,
+        195.84114925861235
+      ],
+      "size": [
+        157.56002807617188,
+        46
+      ],
+      "flags": {},
+      "order": 14,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 164
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 76
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [
+            101
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAEDecode",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 92,
+      "type": "EmptyFlux2LatentImage",
+      "pos": [
+        560.1252292712549,
+        721.3543590454891
+      ],
+      "size": [
+        270,
+        106
+      ],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "width",
+          "type": "INT",
+          "widget": {
+            "name": "width"
+          },
+          "link": 153
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "widget": {
+            "name": "height"
+          },
+          "link": 154
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            152
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "EmptyFlux2LatentImage"
+      },
+      "widgets_values": [
+        1024,
+        1024,
+        1
+      ]
+    },
+    {
+      "id": 91,
+      "type": "CLIPLoader",
+      "pos": [
+        -510.80318076960083,
+        311.42496280403503
+      ],
+      "size": [
+        289.8073985431536,
+        106
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [
+            150
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": [
+        "qwen3vl_8b_fp8_scaled.safetensors",
+        "ideogram4",
+        "default"
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 39,
+      "type": "VAELoader",
+      "pos": [
+        904.0583918587276,
+        72.88171068869869
+      ],
+      "size": [
+        242.12760404770165,
+        58
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "slot_index": 0,
+          "links": [
+            76
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAELoader",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "flux2-vae.safetensors"
+      ],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 79,
+      "type": "SamplerCustomAdvanced",
+      "pos": [
+        904.0583918587276,
+        195.84114925861235
+      ],
+      "size": [
+        242.12760404770165,
+        106
+      ],
+      "flags": {},
+      "order": 13,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "noise",
+          "type": "NOISE",
+          "link": 130
+        },
+        {
+          "name": "guider",
+          "type": "GUIDER",
+          "link": 173
+        },
+        {
+          "name": "sampler",
+          "type": "SAMPLER",
+          "link": 132
+        },
+        {
+          "name": "sigmas",
+          "type": "SIGMAS",
+          "link": 181
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 152
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "type": "LATENT",
+          "links": [
+            164
+          ]
+        },
+        {
+          "name": "denoised_output",
+          "type": "LATENT",
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "SamplerCustomAdvanced",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.60",
+        "enableTabs": false,
+        "tabWidth": 65,
+        "tabXOffset": 10,
+        "hasSecondTab": false,
+        "secondTabText": "Send Back",
+        "secondTabOffset": 80,
+        "secondTabWidth": 65
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 56,
+      "type": "SaveImage",
+      "pos": [
+        1371.5615738427737,
+        195.84114925861235
+      ],
+      "size": [
+        436.7195313170437,
+        711.2421298391242
+      ],
+      "flags": {},
+      "order": 15,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 101
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.75"
+      },
+      "widgets_values": [
+        "ComfyUI"
+      ]
+    },
+    {
+      "id": 94,
+      "type": "ResolutionSelector",
+      "pos": [
+        249.45527396590353,
+        701.3543590454891
+      ],
+      "size": [
+        270,
+        126
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "width",
+          "type": "INT",
+          "links": [
+            153,
+            156
+          ]
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "links": [
+            154,
+            157
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ResolutionSelector"
+      },
+      "widgets_values": [
+        "2:3 (Portrait Photo)",
+        1,
+        16
+      ]
+    },
+    {
+      "id": 110,
+      "type": "CFGGuider",
+      "pos": [
+        560.1252292712549,
+        131.1414897935515
+      ],
+      "size": [
+        270,
+        98
+      ],
+      "flags": {},
+      "order": 12,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 178
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 175
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 176
+        }
+      ],
+      "outputs": [
+        {
+          "name": "GUIDER",
+          "type": "GUIDER",
+          "links": [
+            173
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CFGGuider"
+      },
+      "widgets_values": [
+        1
+      ]
+    },
+    {
+      "id": 83,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -194.71785512781273,
+        311.42496280403503
+      ],
+      "size": [
+        408.34315901785703,
+        324.50164397511764
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 150
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            142,
+            175
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.56",
+        "enableTabs": false,
+        "tabWidth": 65,
+        "tabXOffset": 10,
+        "hasSecondTab": false,
+        "secondTabText": "Send Back",
+        "secondTabOffset": 80,
+        "secondTabWidth": 65
+      },
+      "widgets_values": [
+        "{\n  \"high_level_description\": \"A clean vertical anime-style illustration of a teenage girl kneeling while holding a penguin stretched across her arms. The scene uses a plain white background, soft linework, and a playful fashion twist with sunglasses, a yellow rain outfit, and blue rain boots.\",\n  \"style_description\": {\n    \"aesthetics\": \"Soft Japanese anime illustration with delicate line art, clean negative space, gentle shading, and a calm slice-of-life mood.\",\n    \"lighting\": \"Soft diffused studio lighting with subtle gray contact shadows beneath the figure.\",\n    \"medium\": \"digital illustration\",\n    \"art_style\": \"contemporary anime character illustration\",\n    \"color_palette\": [\n      \"#FFFFFF\",\n      \"#F4D34F\",\n      \"#1F1F1F\",\n      \"#3F6FB6\",\n      \"#F2CDB3\",\n      \"#EAEAEA\"\n    ]\n  },\n  \"compositional_deconstruction\": {\n    \"background\": \"A plain white seamless backdrop with generous negative space around the kneeling subject. A soft gray shadow near the floor lightly grounds the figure and the penguin within the vertical frame.\",\n    \"elements\": [\n      {\n        \"type\": \"obj\",\n        \"bbox\": [120, 140, 940, 730],\n        \"desc\": \"A teenage girl with light skin and straight dark brown shoulder-length hair with bangs, kneeling on one knee in a casual pose. She wears dark sunglasses, a bright yellow hooded raincoat, matching yellow waterproof rain pants with no blue trousers visible, and glossy blue rain boots. Her pose mirrors the reference composition, with one arm supporting the penguin near her shoulder and the other hand holding its lower body. Her expression is mostly hidden by the sunglasses, giving her a cool and composed attitude.\",\n        \"color_palette\": [\n          \"#F2CDB3\",\n          \"#2F2525\",\n          \"#1F1F1F\",\n          \"#F4D34F\",\n          \"#3F6FB6\",\n          \"#F7F7F7\"\n        ]\n      },\n      {\n        \"type\": \"obj\",\n        \"bbox\": [185, 235, 515, 905],\n        \"desc\": \"A penguin held horizontally across the girl's arms in a playful stretched pose, echoing the original composition. The penguin has a black back, white belly, small pale beak, flipper-like wings extended outward, and dangling feet, appearing calm and slightly floppy while being supported.\",\n        \"color_palette\": [\n          \"#1E1E1E\",\n          \"#FFFFFF\",\n          \"#F1D9A6\",\n          \"#D9D9D9\",\n          \"#8A8A8A\"\n        ]\n      }\n    ]\n  }\n}"
+      ]
+    },
+    {
+      "id": 87,
+      "type": "ConditioningZeroOut",
+      "pos": [
+        249.45527396590353,
+        427.0196777116257
+      ],
+      "size": [
+        270,
+        26
+      ],
+      "flags": {},
+      "order": 11,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "conditioning",
+          "type": "CONDITIONING",
+          "link": 142
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            176
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ConditioningZeroOut"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 37,
+      "type": "UNETLoader",
+      "pos": [
+        -96.592885685151,
+        -49.16835585157703
+      ],
+      "size": [
+        305.3782043457031,
+        82
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            177
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "UNETLoader",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "ideogram4_fp8_scaled.safetensors",
+        "default"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 78,
+      "type": "RandomNoise",
+      "pos": [
+        560.1252292712549,
+        -49.16835585157703
+      ],
+      "size": [
+        270,
+        82
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "NOISE",
+          "type": "NOISE",
+          "links": [
+            130
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "RandomNoise",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.56",
+        "enableTabs": false,
+        "tabWidth": 65,
+        "tabXOffset": 10,
+        "hasSecondTab": false,
+        "secondTabText": "Send Back",
+        "secondTabOffset": 80,
+        "secondTabWidth": 65
+      },
+      "widgets_values": [
+        22222,
+        "fixed"
+      ]
+    },
+    {
+      "id": 111,
+      "type": "LoraLoaderModelOnly",
+      "pos": [
+        249.4552739659035,
+        -49.16835585157703
+      ],
+      "size": [
+        270,
+        82
+      ],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 177
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            178
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": [
+        "ideogram_4_turbotime_v1.safetensors",
+        0.6
+      ]
+    },
+    {
+      "id": 95,
+      "type": "Ideogram4Scheduler",
+      "pos": [
+        560.1252292712549,
+        480.44373240455593
+      ],
+      "size": [
+        270,
+        154
+      ],
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "width",
+          "type": "INT",
+          "widget": {
+            "name": "width"
+          },
+          "link": 156
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "widget": {
+            "name": "height"
+          },
+          "link": 157
+        }
+      ],
+      "outputs": [
+        {
+          "name": "SIGMAS",
+          "type": "SIGMAS",
+          "links": [
+            181
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "Ideogram4Scheduler"
+      },
+      "widgets_values": [
+        8,
+        1024,
+        1024,
+        0.5,
+        1.75
+      ]
+    },
+    {
+      "id": 71,
+      "type": "MarkdownNote",
+      "pos": [
+        -569.8787976043636,
+        -155.54437578349516
+      ],
+      "size": [
+        424.61355549024836,
+        362.0090833106222
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "## models\n\n- diffusion_models\n  - [ideogram4_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/diffusion_models/ideogram4_fp8_scaled.safetensors) (9.28 GB)\n  - [ideogram4_nvfp4_mixed.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/diffusion_models/ideogram4_nvfp4_mixed.safetensors) (5.49 GB)\n- loras\n  - [ideogram_4_turbotime_v1.safetensors](https://huggingface.co/ostris/ideogram_4_turbotime_lora/blob/main/ideogram_4_turbotime_v1.safetensors) (847 MB)\n- text_encoders\n  - [qwen3vl_8b_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/text_encoders/qwen3vl_8b_fp8_scaled.safetensors) (10.6 GB)\n- vae\n  - [flux2-vae.safetensors](https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/vae/flux2-vae.safetensors) (336 MB)\n\n```text\n📂ComfyUI/\n└── 📂models/\n    ├── 📂diffusion_models/\n    │   ├── ideogram4_fp8_scaled.safetensors\n    │   └── ideogram4_nvfp4_mixed.safetensors\n    ├── 📂loras/\n    │   └── ideogram_4_turbotime_v1.safetensors\n    ├── 📂text_encoders/\n    │   └── qwen3vl_8b_fp8_scaled.safetensors\n    └── 📂vae/\n         └── flux2-vae.safetensors\n```"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    }
+  ],
+  "links": [
+    [
+      76,
+      39,
+      0,
+      8,
+      1,
+      "VAE"
+    ],
+    [
+      101,
+      8,
+      0,
+      56,
+      0,
+      "IMAGE"
+    ],
+    [
+      130,
+      78,
+      0,
+      79,
+      0,
+      "NOISE"
+    ],
+    [
+      132,
+      76,
+      0,
+      79,
+      2,
+      "SAMPLER"
+    ],
+    [
+      142,
+      83,
+      0,
+      87,
+      0,
+      "CONDITIONING"
+    ],
+    [
+      150,
+      91,
+      0,
+      83,
+      0,
+      "CLIP"
+    ],
+    [
+      152,
+      92,
+      0,
+      79,
+      4,
+      "LATENT"
+    ],
+    [
+      153,
+      94,
+      0,
+      92,
+      0,
+      "INT"
+    ],
+    [
+      154,
+      94,
+      1,
+      92,
+      1,
+      "INT"
+    ],
+    [
+      156,
+      94,
+      0,
+      95,
+      0,
+      "INT"
+    ],
+    [
+      157,
+      94,
+      1,
+      95,
+      1,
+      "INT"
+    ],
+    [
+      164,
+      79,
+      0,
+      8,
+      0,
+      "LATENT"
+    ],
+    [
+      173,
+      110,
+      0,
+      79,
+      1,
+      "GUIDER"
+    ],
+    [
+      175,
+      83,
+      0,
+      110,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      176,
+      87,
+      0,
+      110,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      177,
+      37,
+      0,
+      111,
+      0,
+      "MODEL"
+    ],
+    [
+      178,
+      111,
+      0,
+      110,
+      0,
+      "MODEL"
+    ],
+    [
+      181,
+      95,
+      0,
+      79,
+      3,
+      "SIGMAS"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.5644739300537773,
+      "offset": [
+        890.2257921733324,
+        385.0522096928824
+      ]
+    },
+    "frontendVersion": "1.45.15",
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true
+  },
+  "version": 0.4
+}

--- a/src/workflows/basic-workflows/scail-2/SCAIL-2_Animation_multi-ref.json
+++ b/src/workflows/basic-workflows/scail-2/SCAIL-2_Animation_multi-ref.json
@@ -1,0 +1,2121 @@
+{
+  "id": "d8034549-7e0a-40f1-8c2e-de3ffc6f1cae",
+  "revision": 0,
+  "last_node_id": 142,
+  "last_link_id": 299,
+  "nodes": [
+    {
+      "id": 57,
+      "type": "CLIPVisionLoader",
+      "pos": [
+        251.28673034667955,
+        1235.5962450561526
+      ],
+      "size": [
+        270,
+        58
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP_VISION",
+          "type": "CLIP_VISION",
+          "links": [
+            106
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPVisionLoader",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "clip_vision_h.safetensors"
+      ],
+      "color": "#332922",
+      "bgcolor": "#593930"
+    },
+    {
+      "id": 38,
+      "type": "CLIPLoader",
+      "pos": [
+        56.288665771484375,
+        190.560140854834
+      ],
+      "size": [
+        301.3524169921875,
+        106
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "slot_index": 0,
+          "links": [
+            74,
+            75
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPLoader",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "umt5_xxl_fp8_e4m3fn_scaled.safetensors",
+        "wan",
+        "default"
+      ]
+    },
+    {
+      "id": 7,
+      "type": "CLIPTextEncode",
+      "pos": [
+        417.8738708496094,
+        266.8154509134282
+      ],
+      "size": [
+        419.3189392089844,
+        138.8924560546875
+      ],
+      "flags": {},
+      "order": 11,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 75
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            199
+          ]
+        }
+      ],
+      "title": "CLIP Text Encode (Negative Prompt)",
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走 "
+      ]
+    },
+    {
+      "id": 48,
+      "type": "ModelSamplingSD3",
+      "pos": [
+        621.2813720703125,
+        -84.75058912563465
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {},
+      "order": 18,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 184
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            120
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ModelSamplingSD3",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        5
+      ]
+    },
+    {
+      "id": 102,
+      "type": "ResizeImageMaskNode",
+      "pos": [
+        -1207.1694890534063,
+        1303.0937658090495
+      ],
+      "size": [
+        270,
+        106
+      ],
+      "flags": {},
+      "order": 16,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input",
+          "type": "IMAGE,MASK",
+          "link": 204
+        }
+      ],
+      "outputs": [
+        {
+          "name": "resized",
+          "type": "IMAGE",
+          "links": [
+            203
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ResizeImageMaskNode"
+      },
+      "widgets_values": [
+        "scale total pixels",
+        0.5,
+        "nearest-exact"
+      ],
+      "color": "#233",
+      "bgcolor": "#355"
+    },
+    {
+      "id": 37,
+      "type": "UNETLoader",
+      "pos": [
+        -59.809774398803675,
+        -84.75058912563465
+      ],
+      "size": [
+        305.3782043457031,
+        82
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            183
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "UNETLoader",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "wan2.1_14B_SCAIL_2_fp8_scaled.safetensors",
+        "default"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 96,
+      "type": "LoraLoaderModelOnly",
+      "pos": [
+        276.2320190445451,
+        -84.75058912563465
+      ],
+      "size": [
+        314.38576392812183,
+        82
+      ],
+      "flags": {},
+      "order": 12,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 183
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            184
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoraLoaderModelOnly",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.60"
+      },
+      "widgets_values": [
+        "Wan2.1/Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors",
+        1
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 120,
+      "type": "Reroute",
+      "pos": [
+        1715.7130963493837,
+        468.5779949512076
+      ],
+      "size": [
+        75,
+        26
+      ],
+      "flags": {},
+      "order": 13,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "",
+          "type": "*",
+          "link": 244
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "VAE",
+          "links": [
+            245
+          ]
+        }
+      ],
+      "properties": {
+        "showOutputText": false,
+        "horizontal": false
+      }
+    },
+    {
+      "id": 39,
+      "type": "VAELoader",
+      "pos": [
+        525.0368322106934,
+        468.5779949512076
+      ],
+      "size": [
+        306.36004638671875,
+        58
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "slot_index": 0,
+          "links": [
+            200,
+            244
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAELoader",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "wan_2.1_vae.safetensors"
+      ],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 101,
+      "type": "WanSCAILToVideo",
+      "pos": [
+        1082.8079278436192,
+        604.0725314640773
+      ],
+      "size": [
+        344.02734375,
+        434
+      ],
+      "flags": {},
+      "order": 30,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 198
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 199
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 200
+        },
+        {
+          "name": "pose_video",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": 241
+        },
+        {
+          "name": "pose_video_mask",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": 230
+        },
+        {
+          "name": "reference_image",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": 258
+        },
+        {
+          "name": "reference_image_mask",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": 231
+        },
+        {
+          "name": "clip_vision_output",
+          "shape": 7,
+          "type": "CLIP_VISION_OUTPUT",
+          "link": 202
+        },
+        {
+          "name": "previous_frames",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "width",
+          "type": "INT",
+          "widget": {
+            "name": "width"
+          },
+          "link": 213
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "widget": {
+            "name": "height"
+          },
+          "link": 214
+        }
+      ],
+      "outputs": [
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "links": [
+            215
+          ]
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "links": [
+            216
+          ]
+        },
+        {
+          "name": "latent",
+          "type": "LATENT",
+          "links": [
+            217
+          ]
+        },
+        {
+          "name": "video_frame_offset",
+          "type": "INT",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "WanSCAILToVideo"
+      },
+      "widgets_values": [
+        512,
+        896,
+        81,
+        1,
+        1,
+        0,
+        1,
+        0,
+        5,
+        false
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 119,
+      "type": "Reroute",
+      "pos": [
+        25.7972264472059,
+        669.0146817503652
+      ],
+      "size": [
+        75,
+        26
+      ],
+      "flags": {},
+      "order": 17,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "",
+          "type": "*",
+          "link": 239
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "IMAGE",
+          "links": [
+            240,
+            241
+          ]
+        }
+      ],
+      "properties": {
+        "showOutputText": false,
+        "horizontal": false
+      }
+    },
+    {
+      "id": 123,
+      "type": "MarkdownNote",
+      "pos": [
+        -548.6500412597653,
+        -84.75058912563465
+      ],
+      "size": [
+        461.4852607760207,
+        466.4268689388148
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "## models\n\n- checkpoints\n  - [sam3.1_multiplex_fp16.safetensors](https://huggingface.co/Comfy-Org/sam3.1/blob/main/checkpoints/sam3.1_multiplex_fp16.safetensors)\n- clip_vision\n  - [clip_vision_h.safetensors](https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/blob/main/split_files/clip_vision/clip_vision_h.safetensors)\n- diffusion_models\n  - [wan2.1_14B_SCAIL_2_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/SCAIL-2/blob/main/diffusion_models/wan2.1_14B_SCAIL_2_fp8_scaled.safetensors)\n- loras\n  - [Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors](https://huggingface.co/lightx2v/Wan2.1-I2V-14B-480P-StepDistill-CfgDistill-Lightx2v/blob/main/loras/Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors)\n- text_encoders\n  - [umt5_xxl_fp8_e4m3fn_scaled.safetensors](https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/blob/main/split_files/text_encoders/umt5_xxl_fp8_e4m3fn_scaled.safetensors)\n- vae\n  - [wan_2.1_vae.safetensors](https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/blob/main/split_files/vae/wan_2.1_vae.safetensors)\n\n```text\n📂ComfyUI/\n└── 📂models/\n    ├── 📂checkpoints/\n    │   └── sam3.1_multiplex_fp16.safetensors\n    ├── 📂clip_vision/\n    │   └── clip_vision_h.safetensors\n    ├── 📂diffusion_models/\n    │   └── wan2.1_14B_SCAIL_2_fp8_scaled.safetensors\n    ├── 📂loras/\n    │   └── Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors\n    ├── 📂text_encoders/\n    │   └── umt5_xxl_fp8_e4m3fn_scaled.safetensors\n    └── 📂vae/\n        └── wan_2.1_vae.safetensors\n```"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 110,
+      "type": "CheckpointLoaderSimple",
+      "pos": [
+        -472.9277129444554,
+        773.4790318695161
+      ],
+      "size": [
+        297.3094587159344,
+        98
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            223,
+            238
+          ]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [
+            220,
+            243
+          ]
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple",
+        "cnr_id": "comfy-core",
+        "ver": "0.19.3"
+      },
+      "widgets_values": [
+        "sam3.1_multiplex_fp16.safetensors"
+      ]
+    },
+    {
+      "id": 109,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -140.2924833863619,
+        847.1714690725746
+      ],
+      "size": [
+        250.42005327504967,
+        109.84222389181082
+      ],
+      "flags": {},
+      "order": 14,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 220
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            224
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode",
+        "cnr_id": "comfy-core",
+        "ver": "0.19.3"
+      },
+      "widgets_values": [
+        "human"
+      ],
+      "color": "#2a363b",
+      "bgcolor": "#3f5159"
+    },
+    {
+      "id": 115,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -140.2924833863619,
+        1068.66630403893
+      ],
+      "size": [
+        250.42005327504967,
+        109.84222389181082
+      ],
+      "flags": {},
+      "order": 15,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 243
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            232
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode",
+        "cnr_id": "comfy-core",
+        "ver": "0.19.3"
+      },
+      "widgets_values": [
+        "human"
+      ],
+      "color": "#233",
+      "bgcolor": "#355"
+    },
+    {
+      "id": 116,
+      "type": "SAM3_VideoTrack",
+      "pos": [
+        165.3271034107571,
+        1007.8240766656425
+      ],
+      "size": [
+        215.80859375,
+        166
+      ],
+      "flags": {},
+      "order": 26,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "images",
+          "name": "images",
+          "type": "IMAGE",
+          "link": 260
+        },
+        {
+          "label": "model",
+          "name": "model",
+          "type": "MODEL",
+          "link": 238
+        },
+        {
+          "label": "initial_mask",
+          "name": "initial_mask",
+          "shape": 7,
+          "type": "MASK",
+          "link": null
+        },
+        {
+          "label": "conditioning",
+          "name": "conditioning",
+          "shape": 7,
+          "type": "CONDITIONING",
+          "link": 232
+        }
+      ],
+      "outputs": [
+        {
+          "name": "track_data",
+          "type": "SAM3_TRACK_DATA",
+          "links": [
+            234
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "SAM3_VideoTrack",
+        "cnr_id": "comfy-core",
+        "ver": "0.19.3"
+      },
+      "widgets_values": [
+        0.5,
+        0,
+        1
+      ],
+      "color": "#233",
+      "bgcolor": "#355"
+    },
+    {
+      "id": 107,
+      "type": "SCAIL2ColoredMask",
+      "pos": [
+        506.50542810498916,
+        905.2770955134855
+      ],
+      "size": [
+        339.45703125,
+        126
+      ],
+      "flags": {},
+      "order": 28,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "driving_track_data",
+          "type": "SAM3_TRACK_DATA",
+          "link": 229
+        },
+        {
+          "name": "ref_track_data",
+          "shape": 7,
+          "type": "SAM3_TRACK_DATA,MASK",
+          "link": 234
+        }
+      ],
+      "outputs": [
+        {
+          "name": "pose_video_mask",
+          "type": "IMAGE",
+          "links": [
+            230,
+            236
+          ]
+        },
+        {
+          "name": "reference_image_mask",
+          "type": "IMAGE",
+          "links": [
+            231,
+            250
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "SCAIL2ColoredMask"
+      },
+      "widgets_values": [
+        "",
+        "area",
+        false
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 3,
+      "type": "KSampler",
+      "pos": [
+        1475.7130963493837,
+        583.6899778882896
+      ],
+      "size": [
+        315,
+        262
+      ],
+      "flags": {},
+      "order": 32,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 120
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 215
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 216
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 217
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "slot_index": 0,
+          "links": [
+            218
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "KSampler",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        123,
+        "fixed",
+        6,
+        1,
+        "euler",
+        "simple",
+        1
+      ]
+    },
+    {
+      "id": 56,
+      "type": "CLIPVisionEncode",
+      "pos": [
+        577.9174829101565,
+        1285.8704577026379
+      ],
+      "size": [
+        271.6761474609375,
+        78
+      ],
+      "flags": {},
+      "order": 27,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip_vision",
+          "type": "CLIP_VISION",
+          "link": 106
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 261
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CLIP_VISION_OUTPUT",
+          "type": "CLIP_VISION_OUTPUT",
+          "links": [
+            202
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPVisionEncode",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "none"
+      ],
+      "color": "#332922",
+      "bgcolor": "#593930"
+    },
+    {
+      "id": 104,
+      "type": "GetImageSize",
+      "pos": [
+        628.0734857177738,
+        1427.4710497614878
+      ],
+      "size": [
+        219.10007080078117,
+        136
+      ],
+      "flags": {},
+      "order": 25,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 259
+        }
+      ],
+      "outputs": [
+        {
+          "name": "width",
+          "type": "INT",
+          "links": [
+            213
+          ]
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "links": [
+            214
+          ]
+        },
+        {
+          "name": "batch_size",
+          "type": "INT",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "GetImageSize"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 117,
+      "type": "PreviewImage",
+      "pos": [
+        1287.634225650107,
+        1137.316846620137
+      ],
+      "size": [
+        210,
+        258
+      ],
+      "flags": {},
+      "order": 31,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 250
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "Node name for S&R": "PreviewImage"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 112,
+      "type": "SAM3_VideoTrack",
+      "pos": [
+        159.95932129876255,
+        752.7879912506193
+      ],
+      "size": [
+        215.80859375,
+        166
+      ],
+      "flags": {},
+      "order": 20,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "images",
+          "name": "images",
+          "type": "IMAGE",
+          "link": 240
+        },
+        {
+          "label": "model",
+          "name": "model",
+          "type": "MODEL",
+          "link": 223
+        },
+        {
+          "label": "initial_mask",
+          "name": "initial_mask",
+          "shape": 7,
+          "type": "MASK",
+          "link": null
+        },
+        {
+          "label": "conditioning",
+          "name": "conditioning",
+          "shape": 7,
+          "type": "CONDITIONING",
+          "link": 224
+        }
+      ],
+      "outputs": [
+        {
+          "name": "track_data",
+          "type": "SAM3_TRACK_DATA",
+          "links": [
+            229
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "SAM3_VideoTrack",
+        "cnr_id": "comfy-core",
+        "ver": "0.19.3"
+      },
+      "widgets_values": [
+        0.5,
+        0,
+        1
+      ],
+      "color": "#2a363b",
+      "bgcolor": "#3f5159"
+    },
+    {
+      "id": 6,
+      "type": "CLIPTextEncode",
+      "pos": [
+        417.9232177734375,
+        63.8154509134279
+      ],
+      "size": [
+        419.26959228515625,
+        148.8194122314453
+      ],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 74
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            198
+          ]
+        }
+      ],
+      "title": "CLIP Text Encode (Positive Prompt)",
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "A full-body shot of a young woman with short black hair, standing in front of the wooden entrance door of a cozy narrow corner café, with a bicycle parked beside her, potted plants around the doorway, and lush greenery in the background. She is wearing an oversized gray sweatshirt over a white collared shirt, a long black skirt, a black backpack, and chunky black-and-white sneakers. She poses with one hand on her hip and the other touching her hair."
+      ]
+    },
+    {
+      "id": 58,
+      "type": "LoadImage",
+      "pos": [
+        -1547.2395082357293,
+        1303.0937658090495
+      ],
+      "size": [
+        308.07680913429937,
+        543.642446368963
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            204
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "111.png",
+        "image"
+      ],
+      "color": "#233",
+      "bgcolor": "#355"
+    },
+    {
+      "id": 8,
+      "type": "VAEDecode",
+      "pos": [
+        1831.305390050556,
+        583.6899778882896
+      ],
+      "size": [
+        157.56002807617188,
+        46
+      ],
+      "flags": {},
+      "order": 33,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 218
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 245
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [
+            96
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAEDecode",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 49,
+      "type": "VHS_VideoCombine",
+      "pos": [
+        2022.068537023212,
+        583.6899778882896
+      ],
+      "size": [
+        372.2688903808594,
+        876.4033355712891
+      ],
+      "flags": {},
+      "order": 34,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 96
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VHS_VideoCombine",
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "a7ce59e381934733bfae03b1be029756d6ce936d"
+      },
+      "widgets_values": {
+        "frame_rate": 16,
+        "loop_count": 0,
+        "filename_prefix": "SCAIL-2",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 19,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "paused": false,
+          "params": {
+            "filename": "SCAIL-2_00051.mp4",
+            "subfolder": "",
+            "type": "output",
+            "format": "video/h264-mp4",
+            "frame_rate": 16,
+            "workflow": "SCAIL-2_00051.png",
+            "fullpath": "/home/nomax/working-linux/ComfyUI-dev/output/SCAIL-2_00051.mp4"
+          }
+        }
+      }
+    },
+    {
+      "id": 113,
+      "type": "VHS_LoadVideo",
+      "pos": [
+        -800.6210036236067,
+        455.00750561396774
+      ],
+      "size": [
+        261.6533203125,
+        753.272357822205
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            239
+          ]
+        },
+        {
+          "name": "frame_count",
+          "type": "INT",
+          "links": null
+        },
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "links": null
+        },
+        {
+          "name": "video_info",
+          "type": "VHS_VIDEOINFO",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VHS_LoadVideo",
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "2984ec4c4b93292421888f38db74a5e8802a8ff8"
+      },
+      "widgets_values": {
+        "video": "14637751_2160_3840_30fps.mp4",
+        "force_rate": 16,
+        "custom_width": 0,
+        "custom_height": 0,
+        "frame_load_cap": 81,
+        "skip_first_frames": 0,
+        "select_every_nth": 1,
+        "format": "None",
+        "videopreview": {
+          "hidden": false,
+          "paused": false,
+          "params": {
+            "filename": "14637751_2160_3840_30fps.mp4",
+            "type": "input",
+            "format": "video/mp4",
+            "force_rate": 16,
+            "custom_width": 0,
+            "custom_height": 0,
+            "frame_load_cap": 81,
+            "skip_first_frames": 0,
+            "select_every_nth": 1
+          }
+        }
+      },
+      "color": "#2a363b",
+      "bgcolor": "#3f5159"
+    },
+    {
+      "id": 118,
+      "type": "PreviewImage",
+      "pos": [
+        1041.5040075988006,
+        1137.316846620137
+      ],
+      "size": [
+        210,
+        258
+      ],
+      "flags": {},
+      "order": 29,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 236
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "Node name for S&R": "PreviewImage"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 131,
+      "type": "LoadImage",
+      "pos": [
+        -679.723535475966,
+        1677.3499972227291
+      ],
+      "size": [
+        272.1398741245337,
+        498.3884951116386
+      ],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            295
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "MCNK7B5FR2J9K.png",
+        "image"
+      ],
+      "color": "#233",
+      "bgcolor": "#355"
+    },
+    {
+      "id": 142,
+      "type": "ResizeAndPadImage",
+      "pos": [
+        -361.1898589093359,
+        1677.3499972227291
+      ],
+      "size": [
+        270,
+        130
+      ],
+      "flags": {},
+      "order": 23,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 295
+        },
+        {
+          "name": "target_width",
+          "type": "INT",
+          "widget": {
+            "name": "target_width"
+          },
+          "link": 297
+        },
+        {
+          "name": "target_height",
+          "type": "INT",
+          "widget": {
+            "name": "target_height"
+          },
+          "link": 298
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            296
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ResizeAndPadImage"
+      },
+      "widgets_values": [
+        512,
+        512,
+        "white",
+        "nearest-exact"
+      ],
+      "color": "#233",
+      "bgcolor": "#355"
+    },
+    {
+      "id": 103,
+      "type": "ResizeImageMaskNode",
+      "pos": [
+        -905.1762790053829,
+        1303.0937658090495
+      ],
+      "size": [
+        270,
+        106
+      ],
+      "flags": {},
+      "order": 19,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input",
+          "type": "IMAGE,MASK",
+          "link": 203
+        }
+      ],
+      "outputs": [
+        {
+          "name": "resized",
+          "type": "IMAGE",
+          "links": [
+            253,
+            291
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ResizeImageMaskNode"
+      },
+      "widgets_values": [
+        "scale to multiple",
+        32,
+        "nearest-exact"
+      ],
+      "color": "#233",
+      "bgcolor": "#355"
+    },
+    {
+      "id": 126,
+      "type": "BatchImagesNode",
+      "pos": [
+        -59.19664886131238,
+        1301.870476013184
+      ],
+      "size": [
+        169.6640625,
+        106
+      ],
+      "flags": {},
+      "order": 24,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "image0",
+          "name": "images.image0",
+          "type": "IMAGE",
+          "link": 253
+        },
+        {
+          "label": "image1",
+          "name": "images.image1",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": 299
+        },
+        {
+          "label": "image2",
+          "name": "images.image2",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": 296
+        },
+        {
+          "label": "image3",
+          "name": "images.image3",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            258,
+            259,
+            260,
+            261
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "BatchImagesNode"
+      },
+      "widgets_values": [],
+      "color": "#233",
+      "bgcolor": "#355"
+    },
+    {
+      "id": 140,
+      "type": "ResizeAndPadImage",
+      "pos": [
+        -361.1898589093359,
+        1469.4869888001379
+      ],
+      "size": [
+        270,
+        130
+      ],
+      "flags": {},
+      "order": 22,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 292
+        },
+        {
+          "name": "target_width",
+          "type": "INT",
+          "widget": {
+            "name": "target_width"
+          },
+          "link": 293
+        },
+        {
+          "name": "target_height",
+          "type": "INT",
+          "widget": {
+            "name": "target_height"
+          },
+          "link": 294
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            299
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ResizeAndPadImage"
+      },
+      "widgets_values": [
+        512,
+        512,
+        "white",
+        "nearest-exact"
+      ],
+      "color": "#233",
+      "bgcolor": "#355"
+    },
+    {
+      "id": 141,
+      "type": "GetImageSize",
+      "pos": [
+        -603.1830689573594,
+        1388.4312889467474
+      ],
+      "size": [
+        210,
+        136
+      ],
+      "flags": {},
+      "order": 21,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 291
+        }
+      ],
+      "outputs": [
+        {
+          "name": "width",
+          "type": "INT",
+          "links": [
+            293,
+            297
+          ]
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "links": [
+            294,
+            298
+          ]
+        },
+        {
+          "name": "batch_size",
+          "type": "INT",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "GetImageSize"
+      },
+      "widgets_values": [],
+      "color": "#233",
+      "bgcolor": "#355"
+    },
+    {
+      "id": 124,
+      "type": "LoadImage",
+      "pos": [
+        -994.5246956196573,
+        1469.4869888001379
+      ],
+      "size": [
+        272.1397847629616,
+        481.08541387384594
+      ],
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            292
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "viewfilename=ComfyUI_temp_sjoqx_00001_.png",
+        "image"
+      ],
+      "color": "#233",
+      "bgcolor": "#355"
+    }
+  ],
+  "links": [
+    [
+      74,
+      38,
+      0,
+      6,
+      0,
+      "CLIP"
+    ],
+    [
+      75,
+      38,
+      0,
+      7,
+      0,
+      "CLIP"
+    ],
+    [
+      96,
+      8,
+      0,
+      49,
+      0,
+      "IMAGE"
+    ],
+    [
+      106,
+      57,
+      0,
+      56,
+      0,
+      "CLIP_VISION"
+    ],
+    [
+      120,
+      48,
+      0,
+      3,
+      0,
+      "MODEL"
+    ],
+    [
+      183,
+      37,
+      0,
+      96,
+      0,
+      "MODEL"
+    ],
+    [
+      184,
+      96,
+      0,
+      48,
+      0,
+      "MODEL"
+    ],
+    [
+      198,
+      6,
+      0,
+      101,
+      0,
+      "CONDITIONING"
+    ],
+    [
+      199,
+      7,
+      0,
+      101,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      200,
+      39,
+      0,
+      101,
+      2,
+      "VAE"
+    ],
+    [
+      202,
+      56,
+      0,
+      101,
+      7,
+      "CLIP_VISION_OUTPUT"
+    ],
+    [
+      203,
+      102,
+      0,
+      103,
+      0,
+      "IMAGE"
+    ],
+    [
+      204,
+      58,
+      0,
+      102,
+      0,
+      "IMAGE"
+    ],
+    [
+      213,
+      104,
+      0,
+      101,
+      9,
+      "INT"
+    ],
+    [
+      214,
+      104,
+      1,
+      101,
+      10,
+      "INT"
+    ],
+    [
+      215,
+      101,
+      0,
+      3,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      216,
+      101,
+      1,
+      3,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      217,
+      101,
+      2,
+      3,
+      3,
+      "LATENT"
+    ],
+    [
+      218,
+      3,
+      0,
+      8,
+      0,
+      "LATENT"
+    ],
+    [
+      220,
+      110,
+      1,
+      109,
+      0,
+      "CLIP"
+    ],
+    [
+      223,
+      110,
+      0,
+      112,
+      1,
+      "MODEL"
+    ],
+    [
+      224,
+      109,
+      0,
+      112,
+      3,
+      "CONDITIONING"
+    ],
+    [
+      229,
+      112,
+      0,
+      107,
+      0,
+      "SAM3_TRACK_DATA"
+    ],
+    [
+      230,
+      107,
+      0,
+      101,
+      4,
+      "IMAGE"
+    ],
+    [
+      231,
+      107,
+      1,
+      101,
+      6,
+      "IMAGE"
+    ],
+    [
+      232,
+      115,
+      0,
+      116,
+      3,
+      "CONDITIONING"
+    ],
+    [
+      234,
+      116,
+      0,
+      107,
+      1,
+      "SAM3_TRACK_DATA"
+    ],
+    [
+      236,
+      107,
+      0,
+      118,
+      0,
+      "IMAGE"
+    ],
+    [
+      238,
+      110,
+      0,
+      116,
+      1,
+      "MODEL"
+    ],
+    [
+      239,
+      113,
+      0,
+      119,
+      0,
+      "IMAGE"
+    ],
+    [
+      240,
+      119,
+      0,
+      112,
+      0,
+      "IMAGE"
+    ],
+    [
+      241,
+      119,
+      0,
+      101,
+      3,
+      "IMAGE"
+    ],
+    [
+      243,
+      110,
+      1,
+      115,
+      0,
+      "CLIP"
+    ],
+    [
+      244,
+      39,
+      0,
+      120,
+      0,
+      "VAE"
+    ],
+    [
+      245,
+      120,
+      0,
+      8,
+      1,
+      "VAE"
+    ],
+    [
+      250,
+      107,
+      1,
+      117,
+      0,
+      "IMAGE"
+    ],
+    [
+      253,
+      103,
+      0,
+      126,
+      0,
+      "IMAGE"
+    ],
+    [
+      258,
+      126,
+      0,
+      101,
+      5,
+      "IMAGE"
+    ],
+    [
+      259,
+      126,
+      0,
+      104,
+      0,
+      "IMAGE"
+    ],
+    [
+      260,
+      126,
+      0,
+      116,
+      0,
+      "IMAGE"
+    ],
+    [
+      261,
+      126,
+      0,
+      56,
+      1,
+      "IMAGE"
+    ],
+    [
+      291,
+      103,
+      0,
+      141,
+      0,
+      "IMAGE"
+    ],
+    [
+      292,
+      124,
+      0,
+      140,
+      0,
+      "IMAGE"
+    ],
+    [
+      293,
+      141,
+      0,
+      140,
+      1,
+      "INT"
+    ],
+    [
+      294,
+      141,
+      1,
+      140,
+      2,
+      "INT"
+    ],
+    [
+      295,
+      131,
+      0,
+      142,
+      0,
+      "IMAGE"
+    ],
+    [
+      296,
+      142,
+      0,
+      126,
+      2,
+      "IMAGE"
+    ],
+    [
+      297,
+      141,
+      0,
+      142,
+      1,
+      "INT"
+    ],
+    [
+      298,
+      141,
+      1,
+      142,
+      2,
+      "INT"
+    ],
+    [
+      299,
+      140,
+      0,
+      126,
+      1,
+      "IMAGE"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.42409761837248483,
+      "offset": [
+        1580.994170562551,
+        -434.01628452878845
+      ]
+    },
+    "frontendVersion": "1.45.15",
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true
+  },
+  "version": 0.4
+}


### PR DESCRIPTION
## Summary

- Add SCAIL-2 multi-reference workflow notes across JA/EN/ZH.
- Add Ideogram 4 TurboTime LoRA notes across JA/EN/ZH.
- Add the Ideogram TurboTime text2image workflow JSON.
- Add model file sizes to the SCAIL-2 model download lists.

## Validation

- `git diff --check`
- `npm run check`
- `npm run build`

`npm run check` passed with existing advisory warnings for markdown links and icon currentColor checks.