### PR TITLE
Clarify SCAIL-2 replacement compatibility

### DIFF
--- a/src/content/en/basic-workflows/scail-2.md
+++ b/src/content/en/basic-workflows/scail-2.md
@@ -175,6 +175,8 @@ Set `replacement_mode` to `true`.
 
 ---
 
+> From here on, the examples use Animation mode, but all of them can also be used in Replacement mode.
+
 ## Animation Mode (Multiple People)
 
 SCAIL-2 also supports videos and images with multiple people.
@@ -228,11 +230,11 @@ Input the images you want to reference into `Batch Images`.
 
 Multiple reference images can be used, but this does not automatically adjust the background to the person's size or rewrite the whole image into a natural composition.
 
-Honestly, in many cases it is better to first create a single polished reference image with image editing.
+It is useful for supplementing a person from another angle, but if you want to composite the background, it is better to first create a single polished reference image with image editing.
 
 **Output Example**
 
-![reference image 1](https://gyazo.com/d2935f1c3b0ff3016616c54d88d6be56){gyazo=image} ![reference image 2](https://gyazo.com/7819645aea776b0aa5e24e8d9f642487){gyazo=image} ![reference image 3](https://gyazo.com/4617d933cec4a3431d36af11c65180e3){gyazo=image} ![motion video](https://gyazo.com/5491ba090036cbac5d76abd293d842ef){gyazo=loop} ![output](https://gyazo.com/50154740248550b3ffa1dfee024da941){gyazo=loop}
+![reference image 1](https://gyazo.com/d2935f1c3b0ff3016616c54d88d6be56){gyazo=image} ![reference image 2](https://gyazo.com/7819645aea776b0aa5e24e8d9f642487){gyazo=image} ![reference image 3](https://gyazo.com/4617d933cec4a3431d36af11c65180e3){gyazo=image} ![motion video](https://gyazo.com/f14aef04ac197a4b92680e05c4fbd178){gyazo=loop} ![output](https://gyazo.com/50154740248550b3ffa1dfee024da941){gyazo=loop}
 
 ---
 

--- a/src/content/ja/basic-workflows/scail-2.md
+++ b/src/content/ja/basic-workflows/scail-2.md
@@ -175,6 +175,8 @@ Replacement は動画のサイズが基準になります。
 
 ---
 
+> ここから先は Animation モードを使っていますが、どれも Replacement モードでも使えます。
+
 ## Animation モード (複数人)
 
 SCAIL-2 は複数人の動画・画像にも対応しています。
@@ -228,11 +230,11 @@ SCAIL-2 は複数人の動画・画像にも対応しています。
 
 複数の参照画像は使えますが、人物のサイズに合わせて背景を調整したり、全体を自然にリライトしたりするわけではありません。
 
-正直なところ、この機能を使うより、画像編集で先に参照画像を 1 枚作り込んだほうがよいでしょう。
+別角度からの人物を補うには向いていますが、背景を合成したいなら、この機能を使うより、画像編集で 1 枚作り込んだほうがよいでしょう。
 
 **出力例**
 
-![参照画像1](https://gyazo.com/d2935f1c3b0ff3016616c54d88d6be56){gyazo=image} ![参照画像2](https://gyazo.com/7819645aea776b0aa5e24e8d9f642487){gyazo=image} ![参照画像3](https://gyazo.com/4617d933cec4a3431d36af11c65180e3){gyazo=image} ![モーション用動画](https://gyazo.com/5491ba090036cbac5d76abd293d842ef){gyazo=loop} ![output](https://gyazo.com/50154740248550b3ffa1dfee024da941){gyazo=loop}
+![参照画像1](https://gyazo.com/d2935f1c3b0ff3016616c54d88d6be56){gyazo=image} ![参照画像2](https://gyazo.com/7819645aea776b0aa5e24e8d9f642487){gyazo=image} ![参照画像3](https://gyazo.com/4617d933cec4a3431d36af11c65180e3){gyazo=image} ![モーション用動画](https://gyazo.com/f14aef04ac197a4b92680e05c4fbd178){gyazo=loop} ![output](https://gyazo.com/50154740248550b3ffa1dfee024da941){gyazo=loop}
 
 ---
 

--- a/src/content/zh/basic-workflows/scail-2.md
+++ b/src/content/zh/basic-workflows/scail-2.md
@@ -175,6 +175,8 @@ Replacement 会以视频尺寸为基准。
 
 ---
 
+> 从这里开始的示例使用 Animation 模式，但这些内容也都可以用于 Replacement 模式。
+
 ## Animation 模式（多人）
 
 SCAIL-2 也支持多人视频和图像。
@@ -228,11 +230,11 @@ SCAIL-2 也支持多人视频和图像。
 
 虽然可以使用多张参考图像，但它并不会根据人物大小自动调整背景，也不会把整体自然地重新改写成一张图。
 
-老实说，很多情况下不如先用图像编辑做出 1 张完整的参考图像。
+它适合用来补充人物的其他角度信息，但如果想合成背景，还是先用图像编辑做出 1 张完整的参考图像会更好。
 
 **输出例**
 
-![参考图像 1](https://gyazo.com/d2935f1c3b0ff3016616c54d88d6be56){gyazo=image} ![参考图像 2](https://gyazo.com/7819645aea776b0aa5e24e8d9f642487){gyazo=image} ![参考图像 3](https://gyazo.com/4617d933cec4a3431d36af11c65180e3){gyazo=image} ![动作视频](https://gyazo.com/5491ba090036cbac5d76abd293d842ef){gyazo=loop} ![output](https://gyazo.com/50154740248550b3ffa1dfee024da941){gyazo=loop}
+![参考图像 1](https://gyazo.com/d2935f1c3b0ff3016616c54d88d6be56){gyazo=image} ![参考图像 2](https://gyazo.com/7819645aea776b0aa5e24e8d9f642487){gyazo=image} ![参考图像 3](https://gyazo.com/4617d933cec4a3431d36af11c65180e3){gyazo=image} ![动作视频](https://gyazo.com/f14aef04ac197a4b92680e05c4fbd178){gyazo=loop} ![output](https://gyazo.com/50154740248550b3ffa1dfee024da941){gyazo=loop}
 
 ---
 


### PR DESCRIPTION
## Summary

- Add a note that the later SCAIL-2 examples also work in Replacement mode.
- Refine the multiple-reference guidance across JA/EN/ZH.
- Update the multiple-reference motion video Gyazo URL across JA/EN/ZH.

## Validation

- `git diff --check`
- `npm run check`
- `npm run build`

`npm run check` passed with existing advisory warnings for markdown links and icon currentColor checks.