### PR TITLE
Prevent assistant rail from scrolling article

### DIFF
--- a/src/assets/js/assistant-rail.js
+++ b/src/assets/js/assistant-rail.js
@@ -179,7 +179,6 @@ class AssistantRail {
     this.update();
     window.requestAnimationFrame(() => {
       this.adjustWindowPlacement(target);
-      this.scrollIntoViewIfNeeded();
     });
   }
 
@@ -255,14 +254,6 @@ class AssistantRail {
     if (this.window) {
       this.window.setAttribute("aria-hidden", this.currentView === "panel" ? "true" : "false");
     }
-  }
-
-  scrollIntoViewIfNeeded() {
-    if (!this.root || typeof this.root.scrollIntoView !== "function") return;
-    const behavior = this.prefersReducedMotion ? "auto" : "smooth";
-    window.requestAnimationFrame(() => {
-      this.root.scrollIntoView({ block: "center", behavior });
-    });
   }
 
   adjustWindowPlacement(activeView) {
@@ -565,4 +556,3 @@ function ensureTurnstile() {
   });
   return turnstileReadyPromise;
 }
-

--- a/tests/layout.spec.ts
+++ b/tests/layout.spec.ts
@@ -169,6 +169,48 @@ test.describe("Layout rails", () => {
     await expect(rail).toHaveAttribute("data-view", "panel");
   });
 
+  test("assistant rail choices do not scroll the article", async ({ page }) => {
+    await page.setViewportSize({ width: 1920, height: 1080 });
+    await page.goto(SAMPLE_PAGE);
+    await page.evaluate(() => {
+      const btn = document.querySelector<HTMLButtonElement>(".assistant-rail__avatar");
+      if (btn) {
+        btn.style.opacity = "1";
+        btn.style.visibility = "visible";
+        btn.style.display = "inline-flex";
+        btn.style.pointerEvents = "auto";
+      }
+    });
+
+    const rail = page.locator(".assistant-rail");
+    const openChoiceWithoutScroll = async (viewId: string) => {
+      await page.evaluate(() => window.scrollTo(0, 260));
+      await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(260);
+
+      await page.evaluate((targetViewId) => {
+        const avatar = document.querySelector<HTMLElement>(".assistant-rail__avatar");
+        avatar?.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+        document.querySelector<HTMLElement>(`[data-assistant-target="${targetViewId}"]`)?.click();
+      }, viewId);
+      await expect(rail).toHaveAttribute("data-view", viewId);
+
+      await expect
+        .poll(() => page.evaluate(() => window.scrollY))
+        .toBe(260);
+
+      await page.evaluate((targetViewId) => {
+        document
+          .querySelector<HTMLElement>(`.assistant-rail__view[data-assistant-view="${targetViewId}"] [data-assistant-close]`)
+          ?.click();
+      }, viewId);
+      await expect(rail).toHaveAttribute("data-view", "panel");
+    };
+
+    await openChoiceWithoutScroll("json-help");
+    await openChoiceWithoutScroll("form-correction");
+    await openChoiceWithoutScroll("form-request");
+  });
+
   test("assistant rail form flows through confirm and send", async ({ page }) => {
     const csrfValue = "test-csrf";
     await page.addInitScript(() => {


### PR DESCRIPTION
## What changed

- Removed the assistant rail's automatic `scrollIntoView()` call when opening a selected panel.
- Kept the existing above/below placement calculation for the assistant window.
- Added a Playwright regression test covering `json-help`, `form-correction`, and `form-request` choices without changing article scroll position.

## Why

Selecting any right-rail assistant choice was moving the main document scroll because the rail tried to center itself in the viewport after opening. The widget is already anchored in the right rail, so opening a panel should not scroll the article.

## Impact

Users can open the JSON help, correction report, or article request panels without losing their current reading position.

## Checks

- `git diff --check`
- `npm run check:assets`
- `npm run build`
- `npm run test:playwright -- tests/layout.spec.ts`
- `npm run check`

Known advisory warnings from `npm run check` remain unchanged: 76 markdown link advisories and 22 icon currentColor advisories.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed unintended scroll behavior when opening different assistant views—the article scroll position now remains unchanged when selecting different assistant rail options.

* **Tests**
  * Added test coverage to ensure assistant view selection does not affect page scroll position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->