### PR TITLE
Add Krea 2 workflow page

### DIFF
--- a/ops/adr/2026-06-24-krea-2-page.md
+++ b/ops/adr/2026-06-24-krea-2-page.md
@@ -1,0 +1,29 @@
+# 2026-06-24 Krea 2 Page
+
+## Status
+
+Accepted
+
+## Context
+
+Krea 2 Open-Source has open-weight checkpoints for ComfyUI use. The article should cover the practical Turbo inference path, while noting that Raw is mainly useful for LoRA training and fine-tuning.
+
+## Decision
+
+Add a Japanese source article at `/ja/basic-workflows/krea-2/`, with matching English and Chinese localizations in the same change.
+
+- Section: `basic-workflows`
+- Slug / navId: `krea-2`
+- Navigation placement:
+  - JA: `基本のworkflow` → `他の基盤モデル`, near other foundation image models
+  - EN: `Basic Workflows` → `Other Foundation Models`
+  - ZH: `基本工作流` → corresponding foundation-model group
+- Localization: JA source, EN/ZH pages and nav entries are intentionally included.
+- Workflows:
+  - `src/workflows/basic-workflows/krea-2/Krea_2_turbo_text2image.json`
+  - `src/workflows/basic-workflows/krea-2/Krea_2_turbo_text2image_darkbrush.json`
+- News: add localized news rows for JA/EN/ZH.
+
+## Notes
+
+The page is intentionally short. It documents model placement, minimal text2image settings, and one official style LoRA example.

--- a/src/_data/nav.en.yml
+++ b/src/_data/nav.en.yml
@@ -305,6 +305,8 @@ sections:
             title: PixelDiT / PiD
           - id: ideogram-4
             title: Ideogram 4.0
+          - id: krea-2
+            title: Krea 2
       - id: upscale-fix
         title: Upscale & Fix
         noLink: true

--- a/src/_data/nav.ja.yml
+++ b/src/_data/nav.ja.yml
@@ -305,6 +305,8 @@ sections:
             title: PixelDiT / PiD
           - id: ideogram-4
             title: Ideogram 4.0
+          - id: krea-2
+            title: Krea 2
       - id: upscale-fix
         title: アップスケール・修正
         noLink: true

--- a/src/_data/nav.zh.yml
+++ b/src/_data/nav.zh.yml
@@ -305,6 +305,8 @@ sections:
       title: PixelDiT / PiD
     - id: ideogram-4
       title: Ideogram 4.0
+    - id: krea-2
+      title: Krea 2
   - id: upscale-fix
     title: 放大与修复
     noLink: true

--- a/src/content/en/basic-workflows/krea-2.md
+++ b/src/content/en/basic-workflows/krea-2.md
@@ -1,0 +1,96 @@
+---
+layout: page.njk
+lang: en
+section: basic-workflows
+slug: krea-2
+navId: krea-2
+title: "Krea 2"
+created: 2026-06-24
+updated: 2026-06-24
+summary: "Image generation with Krea 2 Turbo"
+permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
+hero:
+  image: "https://i.gyazo.com/6ce8c9a2f7042a08efbbcdefc8ab6673.png"
+tags: []
+---
+
+## What is Krea 2?
+
+[Krea 2 Open-Source](https://www.krea.ai/krea-2-open-source) is an open-weight image generation model from Krea.
+
+As with [FLUX.1 Krea](https://www.krea.ai/blog/flux-krea-open-source-release), which Krea released earlier, the architecture itself is not especially unusual. Instead, the model feels built with care around the dataset, aiming for beautiful images that do not look overly AI-like.
+
+Two models are available, but for normal image generation you will use Turbo.
+
+- **Krea 2 Raw**
+  - An undistilled base model. Mainly intended for LoRA training and fine-tuning.
+- **Krea 2 Turbo**  
+  - A distilled model that can generate in 8 steps.
+
+> The Web / API version of Krea also has **Krea 2 Medium** and **Krea 2 Large**, but the open-weight release only includes **Raw** and **Turbo**.
+
+---
+
+## Model Download
+
+- diffusion_models
+  - [krea2_turbo_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/Krea-2/blob/main/diffusion_models/krea2_turbo_fp8_scaled.safetensors) (13.1 GB)
+- text_encoders
+  - [qwen3vl_4b_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/Krea-2/blob/main/text_encoders/qwen3vl_4b_fp8_scaled.safetensors) (5.24 GB)
+- vae
+  - [qwen_image_vae.safetensors](https://huggingface.co/Comfy-Org/Krea-2/blob/main/vae/qwen_image_vae.safetensors) (254 MB)
+
+```text
+📂ComfyUI/
+└── 📂models/
+    ├── 📂diffusion_models/
+    │   └── krea2_turbo_fp8_scaled.safetensors
+    ├── 📂text_encoders/
+    │   └── qwen3vl_4b_fp8_scaled.safetensors
+    └── 📂vae/
+        └── qwen_image_vae.safetensors
+```
+
+---
+
+## text2image
+
+![](https://gyazo.com/31bce8c4982ff74992c599268d13374d){gyazo=image}
+
+[](/workflows/basic-workflows/krea-2/Krea_2_turbo_text2image.json)
+
+Krea 2 Turbo is a model for 8-step generation.
+
+- `steps` : 8
+- `cfg` : 1.0
+- Recommended resolution : 1K to 2K
+
+---
+
+## Official Style LoRAs
+
+One of Krea 2's major selling points is style control through features such as Style references and Moodboards, but at the moment those are not released as OSS.
+
+Instead, Krea has released several official style LoRAs, so let's try those.
+
+- [Krea 2 LoRAs](https://huggingface.co/collections/krea/krea-2-loras)
+
+```text
+📂ComfyUI/
+└── 📂models/
+    └── 📂loras/
+        └── *.safetensors
+```
+
+Each LoRA has its own recommended trigger word and strength, so check the model card for the one you use.
+
+### text2image (with LoRA)
+
+![](https://gyazo.com/7a2ec126a289cfa04dd8cb609b6d04e3){gyazo=image}
+
+[](/workflows/basic-workflows/krea-2/Krea_2_turbo_text2image_darkbrush.json)
+
+- Here, [Krea-2-LoRA-darkbrush](https://huggingface.co/krea/Krea-2-LoRA-darkbrush) is used.
+- The trigger word is `monochrome ink wash style`.
+
+I am looking forward to seeing many LoRAs from the community.

--- a/src/content/en/news.md
+++ b/src/content/en/news.md
@@ -5,7 +5,7 @@ slug: news
 navId: news
 title: "News"
 created: 2026-01-15
-updated: 2026-06-11
+updated: 2026-06-24
 summary: "Site updates"
 permalink: "/{{ lang }}/{{ slug }}/"
 tags:
@@ -13,6 +13,11 @@ tags:
 ---
 
 <div class="news-list">
+  <a class="news-row" href="/en/basic-workflows/krea-2/">
+    <span class="news-row__date">2026.6.24</span>
+    <span class="news-row__tag">basic-workflows</span>
+    <span class="news-row__title">Added Krea 2 page</span>
+  </a>
   <a class="news-row" href="/en/basic-workflows/scail-2/">
     <span class="news-row__date">2026.6.11</span>
     <span class="news-row__tag">basic-workflows</span>

--- a/src/content/ja/basic-workflows/krea-2.md
+++ b/src/content/ja/basic-workflows/krea-2.md
@@ -1,0 +1,96 @@
+---
+layout: page.njk
+lang: ja
+section: basic-workflows
+slug: krea-2
+navId: krea-2
+title: "Krea 2"
+created: 2026-06-24
+updated: 2026-06-24
+summary: "Krea 2 Turboでの画像生成"
+permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
+hero:
+  image: "https://i.gyazo.com/6ce8c9a2f7042a08efbbcdefc8ab6673.png"
+tags: []
+---
+
+## Krea 2とは？
+
+[Krea 2 Open-Source](https://www.krea.ai/krea-2-open-source) は、Krea による open weight の画像生成モデルです。
+
+Krea が以前作っていた [FLUX.1 Krea](https://www.krea.ai/blog/flux-krea-open-source-release) もそうでしたが、アーキテクチャとして特別な部分は無いものの、データセットを丁寧に作り、AIらしさが出ない美しい画像を生成できるよう、こだわりを持って作成されています。
+
+2 種類のモデルが公開されていますが、通常の画像生成では Turbo を使用します。
+
+- **Krea 2 Raw**
+  - 蒸留されていないベースモデルです。主に LoRA 学習やファインチューニング向けです。
+- **Krea 2 Turbo**  
+  - 8 steps で生成できる蒸留モデル。
+
+> Krea の Web / API 版には **Krea 2 Medium** や **Krea 2 Large** もありますが、open weight として公開されているのは **Raw** と **Turbo** のみです。
+
+---
+
+## モデルのダウンロード
+
+- diffusion_models
+  - [krea2_turbo_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/Krea-2/blob/main/diffusion_models/krea2_turbo_fp8_scaled.safetensors) (13.1 GB)
+- text_encoders
+  - [qwen3vl_4b_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/Krea-2/blob/main/text_encoders/qwen3vl_4b_fp8_scaled.safetensors) (5.24 GB)
+- vae
+  - [qwen_image_vae.safetensors](https://huggingface.co/Comfy-Org/Krea-2/blob/main/vae/qwen_image_vae.safetensors) (254 MB)
+
+```text
+📂ComfyUI/
+└── 📂models/
+    ├── 📂diffusion_models/
+    │   └── krea2_turbo_fp8_scaled.safetensors
+    ├── 📂text_encoders/
+    │   └── qwen3vl_4b_fp8_scaled.safetensors
+    └── 📂vae/
+        └── qwen_image_vae.safetensors
+```
+
+---
+
+## text2image
+
+![](https://gyazo.com/31bce8c4982ff74992c599268d13374d){gyazo=image}
+
+[](/workflows/basic-workflows/krea-2/Krea_2_turbo_text2image.json)
+
+Krea 2 Turbo は 8 steps 生成用のモデルです。
+
+- `steps` : 8
+- `cfg` : 1.0
+- 推奨解像度 : 1K 〜 2K
+
+---
+
+## 公式スタイル LoRA
+
+Krea 2 の大きな売りのひとつに、Style references や Moodboards といったスタイル制御がありますが、現時点では OSS として公開されていません。
+
+代わりに公式からいくつかスタイル LoRA が公開されているので、試してみましょう。
+
+- [Krea 2 LoRAs](https://huggingface.co/collections/krea/krea-2-loras)
+
+```text
+📂ComfyUI/
+└── 📂models/
+    └── 📂loras/
+        └── *.safetensors
+```
+
+LoRA ごとに推奨 trigger word と強度があるので、各モデルカードを確認してください。
+
+### text2image (with LoRA)
+
+![](https://gyazo.com/7a2ec126a289cfa04dd8cb609b6d04e3){gyazo=image}
+
+[](/workflows/basic-workflows/krea-2/Krea_2_turbo_text2image_darkbrush.json)
+
+- ここでは、[Krea-2-LoRA-darkbrush](https://huggingface.co/krea/Krea-2-LoRA-darkbrush) を使用しています。
+- トリガーワードは `monochrome ink wash style` 。
+
+コミュニティから多くの LoRA が出るのが楽しみですね。

--- a/src/content/ja/news.md
+++ b/src/content/ja/news.md
@@ -5,13 +5,18 @@ slug: news
 navId: news
 title: "更新情報"
 created: 2026-01-15
-updated: 2026-06-11
+updated: 2026-06-24
 summary: "このサイトの更新情報"
 permalink: "/{{ lang }}/{{ slug }}/"
 tags:
   - news
 ---
 <div class="news-list">
+  <a class="news-row" href="/ja/basic-workflows/krea-2/">
+    <span class="news-row__date">2026.6.24</span>
+    <span class="news-row__tag">basic-workflows</span>
+    <span class="news-row__title">Krea 2 のページを追加しました</span>
+  </a>
   <a class="news-row" href="/ja/basic-workflows/scail-2/">
     <span class="news-row__date">2026.6.11</span>
     <span class="news-row__tag">basic-workflows</span>

--- a/src/content/zh/basic-workflows/krea-2.md
+++ b/src/content/zh/basic-workflows/krea-2.md
@@ -1,0 +1,96 @@
+---
+layout: page.njk
+lang: zh
+section: basic-workflows
+slug: krea-2
+navId: krea-2
+title: "Krea 2"
+created: 2026-06-24
+updated: 2026-06-24
+summary: "使用 Krea 2 Turbo 进行图像生成"
+permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
+hero:
+  image: "https://i.gyazo.com/6ce8c9a2f7042a08efbbcdefc8ab6673.png"
+tags: []
+---
+
+## 什么是 Krea 2？
+
+[Krea 2 Open-Source](https://www.krea.ai/krea-2-open-source) 是 Krea 发布的 open weight 图像生成模型。
+
+和 Krea 以前做过的 [FLUX.1 Krea](https://www.krea.ai/blog/flux-krea-open-source-release) 类似，它在架构上并没有特别特殊的部分，而是更像是通过认真整理数据集，努力生成不那么有 AI 感、更加漂亮的图像。
+
+公开了 2 种模型，但通常的图像生成会使用 Turbo。
+
+- **Krea 2 Raw**
+  - 未蒸馏的基础模型。主要用于 LoRA 训练和 fine-tuning。
+- **Krea 2 Turbo**  
+  - 可以用 8 steps 生成的蒸馏模型。
+
+> Krea 的 Web / API 版还有 **Krea 2 Medium** 和 **Krea 2 Large**，但作为 open weight 公开的只有 **Raw** 和 **Turbo**。
+
+---
+
+## 模型的下载
+
+- diffusion_models
+  - [krea2_turbo_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/Krea-2/blob/main/diffusion_models/krea2_turbo_fp8_scaled.safetensors) (13.1 GB)
+- text_encoders
+  - [qwen3vl_4b_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/Krea-2/blob/main/text_encoders/qwen3vl_4b_fp8_scaled.safetensors) (5.24 GB)
+- vae
+  - [qwen_image_vae.safetensors](https://huggingface.co/Comfy-Org/Krea-2/blob/main/vae/qwen_image_vae.safetensors) (254 MB)
+
+```text
+📂ComfyUI/
+└── 📂models/
+    ├── 📂diffusion_models/
+    │   └── krea2_turbo_fp8_scaled.safetensors
+    ├── 📂text_encoders/
+    │   └── qwen3vl_4b_fp8_scaled.safetensors
+    └── 📂vae/
+        └── qwen_image_vae.safetensors
+```
+
+---
+
+## text2image
+
+![](https://gyazo.com/31bce8c4982ff74992c599268d13374d){gyazo=image}
+
+[](/workflows/basic-workflows/krea-2/Krea_2_turbo_text2image.json)
+
+Krea 2 Turbo 是用于 8 steps 生成的模型。
+
+- `steps` : 8
+- `cfg` : 1.0
+- 推荐分辨率 : 1K 〜 2K
+
+---
+
+## 官方 Style LoRA
+
+Krea 2 的一大卖点，是 Style references 和 Moodboards 这类风格控制功能，但目前还没有作为 OSS 公开。
+
+作为替代，官方公开了一些 Style LoRA，可以先试试看。
+
+- [Krea 2 LoRAs](https://huggingface.co/collections/krea/krea-2-loras)
+
+```text
+📂ComfyUI/
+└── 📂models/
+    └── 📂loras/
+        └── *.safetensors
+```
+
+每个 LoRA 都有推荐的 trigger word 和强度，使用前请查看对应的模型卡。
+
+### text2image (with LoRA)
+
+![](https://gyazo.com/7a2ec126a289cfa04dd8cb609b6d04e3){gyazo=image}
+
+[](/workflows/basic-workflows/krea-2/Krea_2_turbo_text2image_darkbrush.json)
+
+- 这里使用的是 [Krea-2-LoRA-darkbrush](https://huggingface.co/krea/Krea-2-LoRA-darkbrush)。
+- trigger word 是 `monochrome ink wash style`。
+
+很期待社区里出现更多 LoRA。

--- a/src/content/zh/news.md
+++ b/src/content/zh/news.md
@@ -5,13 +5,18 @@ slug: news
 navId: news
 title: "更新信息"
 created: 2026-02-05
-updated: 2026-06-11
+updated: 2026-06-24
 summary: "本站的更新信息"
 permalink: "/{{ lang }}/{{ slug }}/"
 tags:
   - news
 ---
 <div class="news-list">
+  <a class="news-row" href="/zh/basic-workflows/krea-2/">
+    <span class="news-row__date">2026.6.24</span>
+    <span class="news-row__tag">basic-workflows</span>
+    <span class="news-row__title">追加了 Krea 2 的页面</span>
+  </a>
   <a class="news-row" href="/zh/basic-workflows/scail-2/">
     <span class="news-row__date">2026.6.11</span>
     <span class="news-row__tag">basic-workflows</span>

--- a/src/workflows/basic-workflows/krea-2/Krea_2_turbo_text2image.json
+++ b/src/workflows/basic-workflows/krea-2/Krea_2_turbo_text2image.json
@@ -1,0 +1,568 @@
+{
+  "id": "d8034549-7e0a-40f1-8c2e-de3ffc6f1cae",
+  "revision": 0,
+  "last_node_id": 62,
+  "last_link_id": 112,
+  "nodes": [
+    {
+      "id": 8,
+      "type": "VAEDecode",
+      "pos": [
+        1252.432861328125,
+        188.1918182373047
+      ],
+      "size": [
+        157.56002807617188,
+        46
+      ],
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 35
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 76
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [
+            101
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33",
+        "Node name for S&R": "VAEDecode"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 37,
+      "type": "UNETLoader",
+      "pos": [
+        528.8914031982422,
+        34.805270385742176
+      ],
+      "size": [
+        305.3782043457031,
+        82
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            105
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33",
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": [
+        "krea2_turbo_fp8_scaled.safetensors",
+        "default"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 38,
+      "type": "CLIPLoader",
+      "pos": [
+        56.288665771484375,
+        312.74468994140625
+      ],
+      "size": [
+        301.3524169921875,
+        106
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "slot_index": 0,
+          "links": [
+            74,
+            75
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33",
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": [
+        "qwen3vl_4b_fp8_scaled.safetensors",
+        "krea2",
+        "default"
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 7,
+      "type": "CLIPTextEncode",
+      "pos": [
+        415.00001525878906,
+        429.43443512719523
+      ],
+      "size": [
+        419.26959228515625,
+        107.08506774902344
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 75
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            52
+          ]
+        }
+      ],
+      "title": "CLIP Text Encode (Negative Prompt)",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33",
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        ""
+      ]
+    },
+    {
+      "id": 62,
+      "type": "EmptyLatentImage",
+      "pos": [
+        597.2696075439453,
+        505.0728606096232
+      ],
+      "size": [
+        237,
+        106
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "width",
+          "type": "INT",
+          "widget": {
+            "name": "width"
+          },
+          "link": 110
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "widget": {
+            "name": "height"
+          },
+          "link": 111
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            112
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.26.0",
+        "Node name for S&R": "EmptyLatentImage"
+      },
+      "widgets_values": [
+        512,
+        512,
+        1
+      ]
+    },
+    {
+      "id": 3,
+      "type": "KSampler",
+      "pos": [
+        898.7548217773438,
+        188.1918182373047
+      ],
+      "size": [
+        315,
+        262
+      ],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 105
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 46
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 52
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 112
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "slot_index": 0,
+          "links": [
+            35
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33",
+        "Node name for S&R": "KSampler"
+      },
+      "widgets_values": [
+        12345,
+        "fixed",
+        8,
+        1,
+        "euler",
+        "simple",
+        1
+      ]
+    },
+    {
+      "id": 60,
+      "type": "ResolutionSelector",
+      "pos": [
+        290.29125126341165,
+        530.2598267434913
+      ],
+      "size": [
+        270,
+        126
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "width",
+          "type": "INT",
+          "links": [
+            110
+          ]
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "links": [
+            111
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.25.0",
+        "Node name for S&R": "ResolutionSelector"
+      },
+      "widgets_values": [
+        "3:2 (Photo)",
+        1,
+        16
+      ]
+    },
+    {
+      "id": 6,
+      "type": "CLIPTextEncode",
+      "pos": [
+        415.7513025457208,
+        186
+      ],
+      "size": [
+        418.5183049982245,
+        177.7917699892659
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 74
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            46
+          ]
+        }
+      ],
+      "title": "CLIP Text Encode (Positive Prompt)",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33",
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A highly stylized anime illustration, viewed from a high-angle three-quarter perspective, showing an old compact car dramatically stranded in shallow coastal water among large rocks, as if it ran aground and got stuck there. The car is tilted unevenly and wedged against multiple rocks, creating a more dynamic and three-dimensional stranded composition. The surrounding environment is a natural rocky shoreline with bright blue seawater, scattered stones under the water, and no alley, no wall, no air-conditioning units, no urban background, no tree, no graffiti, and no city clutter.\n\nA desperate young woman sits on the roof of the car near a large hand-painted \"SOS\" sign. She has messy blonde hair and a visibly exhausted, worn-down expression. She is urgently drinking from a nearly empty plastic water bottle, as if she is rationing the last of it. Her posture should feel tense, drained, and survival-oriented, not relaxed or casual. She wears a pale light blue jumpsuit that is heavily worn, torn, dirty, and damaged, with frayed fabric and signs of hardship. Her body language and face should suggest thirst, fatigue, and isolation.\n\nThe car is old, weathered, faded, rusted, and damaged, with cracked windows and a harsh sun-bleached surface. Strong cloud shadows pass dramatically over the woman, the car, the rocks, and the water, creating bold shifting patches of light and shadow. Flat cel-shaded anime style, graphic poster-like composition, bold simplified shapes, clean linework, slightly exaggerated perspective, painterly digital texture, quiet but intense survival mood, vivid cyan-blue water, pale rocks, faded vehicle colors, strong atmospheric lighting, no photorealism, no 3D render."
+      ]
+    },
+    {
+      "id": 56,
+      "type": "SaveImage",
+      "pos": [
+        1443.3798111474612,
+        188.1918182373047
+      ],
+      "size": [
+        891.9094287281766,
+        655.7764006766484
+      ],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 101
+        }
+      ],
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.75"
+      },
+      "widgets_values": [
+        "ComfyUI"
+      ]
+    },
+    {
+      "id": 55,
+      "type": "MarkdownNote",
+      "pos": [
+        -41.61175607181954,
+        -85.90566140100125
+      ],
+      "size": [
+        389.61380077225,
+        288.1499138219051
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "## models\n\n- diffusion_models\n  - [krea2_turbo_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/Krea-2/blob/main/diffusion_models/krea2_turbo_fp8_scaled.safetensors) (13.1 GB)\n- text_encoders\n  - [qwen3vl_4b_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/Krea-2/blob/main/text_encoders/qwen3vl_4b_fp8_scaled.safetensors) (5.24 GB)\n- vae\n  - [qwen_image_vae.safetensors](https://huggingface.co/Comfy-Org/Krea-2/blob/main/vae/qwen_image_vae.safetensors) (254 MB)\n\n```text\n📂ComfyUI/\n└── 📂models/\n    ├── 📂diffusion_models/\n    │   └── krea2_turbo_fp8_scaled.safetensors\n    ├── 📂text_encoders/\n    │   └── qwen3vl_4b_fp8_scaled.safetensors\n    └── 📂vae/\n        └── qwen_image_vae.safetensors\n```"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 39,
+      "type": "VAELoader",
+      "pos": [
+        951.5002075195309,
+        58.805270385742176
+      ],
+      "size": [
+        262.2546142578128,
+        58
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "slot_index": 0,
+          "links": [
+            76
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33",
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": [
+        "qwen_image_vae.safetensors"
+      ],
+      "color": "#322",
+      "bgcolor": "#533"
+    }
+  ],
+  "links": [
+    [
+      35,
+      3,
+      0,
+      8,
+      0,
+      "LATENT"
+    ],
+    [
+      46,
+      6,
+      0,
+      3,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      52,
+      7,
+      0,
+      3,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      74,
+      38,
+      0,
+      6,
+      0,
+      "CLIP"
+    ],
+    [
+      75,
+      38,
+      0,
+      7,
+      0,
+      "CLIP"
+    ],
+    [
+      76,
+      39,
+      0,
+      8,
+      1,
+      "VAE"
+    ],
+    [
+      101,
+      8,
+      0,
+      56,
+      0,
+      "IMAGE"
+    ],
+    [
+      105,
+      37,
+      0,
+      3,
+      0,
+      "MODEL"
+    ],
+    [
+      110,
+      60,
+      0,
+      62,
+      0,
+      "INT"
+    ],
+    [
+      111,
+      60,
+      1,
+      62,
+      1,
+      "INT"
+    ],
+    [
+      112,
+      62,
+      0,
+      3,
+      3,
+      "LATENT"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.620921323059155,
+      "offset": [
+        162.407381471326,
+        370.8669615172955
+      ]
+    },
+    "frontendVersion": "1.45.19",
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true
+  },
+  "version": 0.4
+}

--- a/src/workflows/basic-workflows/krea-2/Krea_2_turbo_text2image_darkbrush.json
+++ b/src/workflows/basic-workflows/krea-2/Krea_2_turbo_text2image_darkbrush.json
@@ -1,0 +1,618 @@
+{
+  "id": "d8034549-7e0a-40f1-8c2e-de3ffc6f1cae",
+  "revision": 0,
+  "last_node_id": 63,
+  "last_link_id": 114,
+  "nodes": [
+    {
+      "id": 8,
+      "type": "VAEDecode",
+      "pos": [
+        1252.432861328125,
+        188.1918182373047
+      ],
+      "size": [
+        157.56002807617188,
+        46
+      ],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 35
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 76
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [
+            101
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33",
+        "Node name for S&R": "VAEDecode"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 38,
+      "type": "CLIPLoader",
+      "pos": [
+        56.288665771484375,
+        312.74468994140625
+      ],
+      "size": [
+        301.3524169921875,
+        106
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "slot_index": 0,
+          "links": [
+            74,
+            75
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33",
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": [
+        "qwen3vl_4b_fp8_scaled.safetensors",
+        "krea2",
+        "default"
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 7,
+      "type": "CLIPTextEncode",
+      "pos": [
+        415.00001525878906,
+        429.43443512719523
+      ],
+      "size": [
+        419.26959228515625,
+        107.08506774902344
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 75
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            52
+          ]
+        }
+      ],
+      "title": "CLIP Text Encode (Negative Prompt)",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33",
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        ""
+      ]
+    },
+    {
+      "id": 62,
+      "type": "EmptyLatentImage",
+      "pos": [
+        597.2696075439453,
+        505.0728606096232
+      ],
+      "size": [
+        237,
+        106
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "width",
+          "type": "INT",
+          "widget": {
+            "name": "width"
+          },
+          "link": 110
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "widget": {
+            "name": "height"
+          },
+          "link": 111
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            112
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.26.0",
+        "Node name for S&R": "EmptyLatentImage"
+      },
+      "widgets_values": [
+        512,
+        512,
+        1
+      ]
+    },
+    {
+      "id": 60,
+      "type": "ResolutionSelector",
+      "pos": [
+        290.29125126341165,
+        530.2598267434913
+      ],
+      "size": [
+        270,
+        126
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "width",
+          "type": "INT",
+          "links": [
+            110
+          ]
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "links": [
+            111
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.25.0",
+        "Node name for S&R": "ResolutionSelector"
+      },
+      "widgets_values": [
+        "3:2 (Photo)",
+        1,
+        16
+      ]
+    },
+    {
+      "id": 56,
+      "type": "SaveImage",
+      "pos": [
+        1443.3798111474612,
+        188.1918182373047
+      ],
+      "size": [
+        891.9094287281766,
+        655.7764006766484
+      ],
+      "flags": {},
+      "order": 11,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 101
+        }
+      ],
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.75"
+      },
+      "widgets_values": [
+        "ComfyUI"
+      ]
+    },
+    {
+      "id": 39,
+      "type": "VAELoader",
+      "pos": [
+        951.5002075195309,
+        58.805270385742176
+      ],
+      "size": [
+        262.2546142578128,
+        58
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "slot_index": 0,
+          "links": [
+            76
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33",
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": [
+        "qwen_image_vae.safetensors"
+      ],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 37,
+      "type": "UNETLoader",
+      "pos": [
+        230.43604514382105,
+        34.805270385742176
+      ],
+      "size": [
+        305.3782043457031,
+        82
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            113
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33",
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": [
+        "krea2_turbo_fp8_scaled.safetensors",
+        "default"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 63,
+      "type": "LoraLoaderModelOnly",
+      "pos": [
+        564.2696075439453,
+        34.805270385742176
+      ],
+      "size": [
+        270,
+        82
+      ],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 113
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            114
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.26.0",
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": [
+        "darkbrush.safetensors",
+        1
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 6,
+      "type": "CLIPTextEncode",
+      "pos": [
+        415.7513025457208,
+        186
+      ],
+      "size": [
+        418.5183049982245,
+        177.7917699892659
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 74
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            46
+          ]
+        }
+      ],
+      "title": "CLIP Text Encode (Positive Prompt)",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33",
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "A rugged Land Cruiser-like off-road vehicle is stranded in shallow coastal water among large rocks at night, as if it ran aground and became stuck there. The vehicle is slightly tilted and wedged against rocks, creating a dynamic stranded composition. The surrounding environment is a natural rocky shoreline with dark seawater and scattered stones visible beneath the surface. Beside the vehicle, a small campfire burns near the shore, and its light reflects beautifully across the water, creating shimmering highlights on the waves and wet rocks. Near the fire, simple clothes are hanging to dry on a rough makeshift drying rack built from improvised wooden branches and sticks.\n\nOn top of the vehicle, a man in worn backpacker-style clothing lies resting on the roof while using binoculars to look up at the night sky. He feels like a lone traveler surviving in isolation, calm and contemplative. His outfit is practical and weathered, suitable for travel and outdoor survival. The vehicle is old, dusty, damaged, and worn, with cracked windows and a harsh exposed surface. The overall mood is quiet, isolated, and atmospheric, with strong contrast between deep night shadows and soft firelight reflections.\n\nStrictly grayscale, black and white only, monochrome image, no color accents, no vivid hues, ink-like tonal rendering, monochrome ink wash style"
+      ]
+    },
+    {
+      "id": 3,
+      "type": "KSampler",
+      "pos": [
+        898.7548217773438,
+        188.1918182373047
+      ],
+      "size": [
+        315,
+        262
+      ],
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 114
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 46
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 52
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 112
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "slot_index": 0,
+          "links": [
+            35
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33",
+        "Node name for S&R": "KSampler"
+      },
+      "widgets_values": [
+        12345,
+        "fixed",
+        8,
+        1,
+        "euler",
+        "simple",
+        1
+      ]
+    },
+    {
+      "id": 55,
+      "type": "MarkdownNote",
+      "pos": [
+        -209.04969164088908,
+        -96.21273705765634
+      ],
+      "size": [
+        400.3576528674205,
+        340.2160093474733
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "## models\n\n- diffusion_models\n  - [krea2_turbo_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/Krea-2/blob/main/diffusion_models/krea2_turbo_fp8_scaled.safetensors) (13.1 GB)\n- loras\n  - [darkbrush.safetensors](https://huggingface.co/krea/Krea-2-LoRA-darkbrush/blob/main/darkbrush.safetensors) (469 MB)\n- text_encoders\n  - [qwen3vl_4b_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/Krea-2/blob/main/text_encoders/qwen3vl_4b_fp8_scaled.safetensors) (5.24 GB)\n- vae\n  - [qwen_image_vae.safetensors](https://huggingface.co/Comfy-Org/Krea-2/blob/main/vae/qwen_image_vae.safetensors) (254 MB)\n\n```text\n📂ComfyUI/\n└── 📂models/\n    ├── 📂diffusion_models/\n    │   └── krea2_turbo_fp8_scaled.safetensors\n    ├── 📂loras/\n    │   └── darkbrush.safetensors\n    ├── 📂text_encoders/\n    │   └── qwen3vl_4b_fp8_scaled.safetensors\n    └── 📂vae/\n        └── qwen_image_vae.safetensors\n```"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    }
+  ],
+  "links": [
+    [
+      35,
+      3,
+      0,
+      8,
+      0,
+      "LATENT"
+    ],
+    [
+      46,
+      6,
+      0,
+      3,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      52,
+      7,
+      0,
+      3,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      74,
+      38,
+      0,
+      6,
+      0,
+      "CLIP"
+    ],
+    [
+      75,
+      38,
+      0,
+      7,
+      0,
+      "CLIP"
+    ],
+    [
+      76,
+      39,
+      0,
+      8,
+      1,
+      "VAE"
+    ],
+    [
+      101,
+      8,
+      0,
+      56,
+      0,
+      "IMAGE"
+    ],
+    [
+      110,
+      60,
+      0,
+      62,
+      0,
+      "INT"
+    ],
+    [
+      111,
+      60,
+      1,
+      62,
+      1,
+      "INT"
+    ],
+    [
+      112,
+      62,
+      0,
+      3,
+      3,
+      "LATENT"
+    ],
+    [
+      113,
+      37,
+      0,
+      63,
+      0,
+      "MODEL"
+    ],
+    [
+      114,
+      63,
+      0,
+      3,
+      0,
+      "MODEL"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 1.1,
+      "offset": [
+        -116.02518234177342,
+        113.02958189026839
+      ]
+    },
+    "frontendVersion": "1.45.19",
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true
+  },
+  "version": 0.4
+}


### PR DESCRIPTION
## Summary

- Add the Krea 2 basic workflow article in JA/EN/ZH.
- Add JA/EN/ZH navigation and news entries for the new page.
- Add two Krea 2 Turbo workflow JSON assets:
  - `Krea_2_turbo_text2image.json`
  - `Krea_2_turbo_text2image_darkbrush.json`
- Record the IA/localization/workflow decision in an ADR.

## Notes

- The page focuses on the open-weight Krea 2 Turbo path for ComfyUI.
- The LoRA example uses the official `Krea-2-LoRA-darkbrush` workflow.

## Checks

- `git diff --check`
- JSON parse validation for both Krea 2 workflow files
- `npm run check`
- `npm run build`
- `npm run test:playwright`

## Advisory Warnings

- `npm run check` still reports existing advisory warnings:
  - 76 markdown link advisory issues
  - 22 icon `currentColor` advisory issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Krea 2 workflow guide in English, Japanese, and Chinese.
  * Added navigation links so the page appears in the basic workflows model lists across all locales.
  * Included ready-to-use text-to-image workflow files, including a variant with an official-style LoRA example.

* **Documentation**
  * Published a news entry for the new Krea 2 page in all supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->