### PR TITLE
Update BiRefNet workflow notes

### DIFF
--- a/src/content/en/data-utilities/birefnet.md
+++ b/src/content/en/data-utilities/birefnet.md
@@ -6,11 +6,11 @@ slug: birefnet
 navId: birefnet
 title: "BiRefNet"
 created: 2026-05-30
-updated: 2026-05-30
+updated: 2026-06-24
 summary: "Background removal and mask generation with BiRefNet"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:
-  image: ""
+  image: "https://i.gyazo.com/2e42734281821aa3f28153af9ba6a08e.png"
 ---
 
 ## What is BiRefNet?
@@ -38,11 +38,25 @@ It is not like SAM, where you specify "this point", "this box", or "this object"
 
 ## workflow
 
-### Background Removal
+### Cut Out the Foreground
 
-![](https://gyazo.com/0c2c21a3dd7088141b67a66b44c80b3a){gyazo=image}
+![](https://gyazo.com/57972a01d12b0d8e88ef705c18344651){gyazo=image}
 
 [](/workflows/data-utilities/birefnet/BiRefNet.json)
 
 - Use `Load Background Removal Model` to load `birefnet.safetensors`.
 - Input the image and model into `Remove Background` to output a background-removal `MASK`.
+- Use `Join Image with Alpha` when you want an image with a transparent background.
+  - If you use the mask as-is, the foreground becomes transparent, so insert `Invert Mask` first.
+
+### Fill the Background
+
+The workflow above makes the background transparent, but for preprocessing in image generation or analysis, it is often easier to fill the background with a solid color.
+
+![](https://gyazo.com/5d22ae3e905a8ccd3c1b8c63f615bb4e){gyazo=image}
+
+[](/workflows/data-utilities/birefnet/BiRefNet_fill.json)
+
+- Input the original image, inverted mask, and solid-color image into `Image Composite Masked`.
+- Only the masked background area is replaced with the solid-color image.
+- See [Layer Composite](/en/data-utilities/layer-composite-blend/) for details.

--- a/src/content/ja/data-utilities/birefnet.md
+++ b/src/content/ja/data-utilities/birefnet.md
@@ -6,11 +6,11 @@ slug: birefnet
 navId: birefnet
 title: "BiRefNet"
 created: 2026-05-30
-updated: 2026-05-30
+updated: 2026-06-24
 summary: "BiRefNet を使った背景除去とマスク生成"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:
-  image: ""
+  image: "https://i.gyazo.com/2e42734281821aa3f28153af9ba6a08e.png"
 ---
 
 ## BiRefNetとは？
@@ -38,11 +38,25 @@ SAM のように「この点」「この箱」「この物体」と指定して�
 
 ## workflow
 
-### 背景除去
+### 前景を切り抜く
 
-![](https://gyazo.com/0c2c21a3dd7088141b67a66b44c80b3a){gyazo=image}
+![](https://gyazo.com/57972a01d12b0d8e88ef705c18344651){gyazo=image}
 
 [](/workflows/data-utilities/birefnet/BiRefNet.json)
 
 - `Load Background Removal Model` で `birefnet.safetensors` を読み込みます。
 - `Remove Background` に画像とモデルを入力すると、背景除去用の `MASK` が出力されます。
+- 背景が透過された画像が欲しいときは `Join Image with Alpha` を使います。
+  - ただし、そのまま使うと前景側が透明になってしまうので、`Invert Mask` を挟みます。
+
+### 背景を塗りつぶす
+
+上の workflow では背景を透過しましたが、画像生成や解析の下処理として使う場合は、背景を単色で塗りつぶしたほうが扱いやすいことも多いです。
+
+![](https://gyazo.com/5d22ae3e905a8ccd3c1b8c63f615bb4e){gyazo=image}
+
+[](/workflows/data-utilities/birefnet/BiRefNet_fill.json)
+
+- `Image Composite Masked` に元画像、反転マスク、単色画像を入力します。
+- マスクされた背景部分だけを単色画像で置き換えます。
+- 詳しくは [レイヤ合成](/ja/data-utilities/layer-composite-blend/) をご覧ください。

--- a/src/content/zh/data-utilities/birefnet.md
+++ b/src/content/zh/data-utilities/birefnet.md
@@ -6,11 +6,11 @@ slug: birefnet
 navId: birefnet
 title: "BiRefNet"
 created: 2026-05-30
-updated: 2026-05-30
+updated: 2026-06-24
 summary: "使用 BiRefNet 进行背景去除和蒙版生成"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:
-  image: ""
+  image: "https://i.gyazo.com/2e42734281821aa3f28153af9ba6a08e.png"
 ---
 
 ## BiRefNet 是什么？
@@ -38,11 +38,25 @@ BiRefNet 是用于背景去除和抠图的模型。
 
 ## workflow
 
-### 背景去除
+### 切出前景
 
-![](https://gyazo.com/0c2c21a3dd7088141b67a66b44c80b3a){gyazo=image}
+![](https://gyazo.com/57972a01d12b0d8e88ef705c18344651){gyazo=image}
 
 [](/workflows/data-utilities/birefnet/BiRefNet.json)
 
 - 使用 `Load Background Removal Model` 读取 `birefnet.safetensors`。
 - 将图像和模型输入 `Remove Background` 后，会输出用于背景去除的 `MASK`。
+- 想要背景透明的图像时，使用 `Join Image with Alpha`。
+  - 但如果直接使用这个蒙版，前景会变透明，所以中间要接一个 `Invert Mask`。
+
+### 填充背景
+
+上面的 workflow 会把背景变为透明，但作为图像生成或分析的预处理使用时，把背景填充成单色通常更容易处理。
+
+![](https://gyazo.com/5d22ae3e905a8ccd3c1b8c63f615bb4e){gyazo=image}
+
+[](/workflows/data-utilities/birefnet/BiRefNet_fill.json)
+
+- 将原图、反转后的蒙版、单色图像输入 `Image Composite Masked`。
+- 只把被蒙版选中的背景部分替换为单色图像。
+- 详情请参考 [图层合成](/zh/data-utilities/layer-composite-blend/)。

--- a/src/workflows/data-utilities/birefnet/BiRefNet_fill.json
+++ b/src/workflows/data-utilities/birefnet/BiRefNet_fill.json
@@ -1,18 +1,18 @@
 {
   "id": "32d5b916-1532-435e-8274-bab16b8cce42",
   "revision": 0,
-  "last_node_id": 15,
-  "last_link_id": 18,
+  "last_node_id": 13,
+  "last_link_id": 20,
   "nodes": [
     {
       "id": 3,
       "type": "LoadBackgroundRemovalModel",
       "pos": [
-        769.3428839311762,
-        373.2630368921259
+        776.2984792746487,
+        215.5777412691436
       ],
       "size": [
-        328.627516211709,
+        325.9727446183857,
         58
       ],
       "flags": {},
@@ -43,15 +43,15 @@
       "id": 1,
       "type": "RemoveBackground",
       "pos": [
-        1140.4167084744367,
-        373.2630368921259
+        1145.3690790242017,
+        215.5777412691436
       ],
       "size": [
         204.705078125,
         46
       ],
       "flags": {},
-      "order": 2,
+      "order": 4,
       "mode": 0,
       "inputs": [
         {
@@ -70,8 +70,7 @@
           "name": "mask",
           "type": "MASK",
           "links": [
-            3,
-            13
+            15
           ]
         }
       ],
@@ -85,24 +84,24 @@
       "bgcolor": "#353"
     },
     {
-      "id": 10,
+      "id": 11,
       "type": "InvertMask",
       "pos": [
-        1387.568094930988,
-        373.2630368921259
+        1393.172012280369,
+        215.5777412691436
       ],
       "size": [
         140,
         26
       ],
       "flags": {},
-      "order": 4,
+      "order": 5,
       "mode": 0,
       "inputs": [
         {
           "name": "mask",
           "type": "MASK",
-          "link": 13
+          "link": 15
         }
       ],
       "outputs": [
@@ -110,7 +109,7 @@
           "name": "MASK",
           "type": "MASK",
           "links": [
-            15
+            16
           ]
         }
       ],
@@ -124,44 +123,15 @@
       "bgcolor": "#653"
     },
     {
-      "id": 4,
-      "type": "MaskPreview",
+      "id": 12,
+      "type": "ColorToRGBInt",
       "pos": [
-        1387.568094930988,
-        617.9104524429572
+        1262.8057138281881,
+        426.71661130361684
       ],
       "size": [
-        261.7862348244132,
-        283.74516954429964
-      ],
-      "flags": {},
-      "order": 3,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "mask",
-          "type": "MASK",
-          "link": 3
-        }
-      ],
-      "outputs": [],
-      "properties": {
-        "cnr_id": "comfy-core",
-        "ver": "0.26.0",
-        "Node name for S&R": "MaskPreview"
-      },
-      "widgets_values": []
-    },
-    {
-      "id": 2,
-      "type": "LoadImage",
-      "pos": [
-        769.3428839311762,
-        494.9638574769056
-      ],
-      "size": [
-        328.627516211709,
-        406.6917645103512
+        270,
+        78
       ],
       "flags": {},
       "order": 1,
@@ -169,53 +139,51 @@
       "inputs": [],
       "outputs": [
         {
-          "name": "IMAGE",
-          "type": "IMAGE",
+          "name": "rgb_int",
+          "type": "INT",
           "links": [
-            8,
-            16
+            19
           ]
         },
         {
-          "name": "MASK",
-          "type": "MASK",
-          "links": []
+          "name": "hex",
+          "type": "COLOR",
+          "links": null
         }
       ],
       "properties": {
         "cnr_id": "comfy-core",
         "ver": "0.26.0",
-        "Node name for S&R": "LoadImage"
+        "Node name for S&R": "ColorToRGBInt"
       },
       "widgets_values": [
-        "normal02_input.jpg",
-        "image"
-      ]
+        "#ffffff"
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
     },
     {
-      "id": 11,
-      "type": "JoinImageWithAlpha",
+      "id": 10,
+      "type": "EmptyImage",
       "pos": [
-        1587.4157037841544,
-        494.9638574769056
+        1262.8055334741948,
+        555.658608688232
       ],
       "size": [
-        216.6609912109374,
-        46
+        270,
+        130
       ],
       "flags": {},
-      "order": 5,
+      "order": 3,
       "mode": 0,
       "inputs": [
         {
-          "name": "image",
-          "type": "IMAGE",
-          "link": 16
-        },
-        {
-          "name": "alpha",
-          "type": "MASK",
-          "link": 15
+          "name": "color",
+          "type": "INT",
+          "widget": {
+            "name": "color"
+          },
+          "link": 19
         }
       ],
       "outputs": [
@@ -230,31 +198,130 @@
       "properties": {
         "cnr_id": "comfy-core",
         "ver": "0.26.0",
-        "Node name for S&R": "JoinImageWithAlpha"
+        "Node name for S&R": "EmptyImage"
       },
-      "widgets_values": [],
+      "widgets_values": [
+        1024,
+        1024,
+        1,
+        0
+      ],
       "color": "#432",
       "bgcolor": "#653"
     },
     {
-      "id": 15,
-      "type": "SaveImage",
+      "id": 2,
+      "type": "LoadImage",
       "pos": [
-        1841.5916728163381,
-        494.9638574769056
+        775.1632258740977,
+        335.574967141765
       ],
       "size": [
-        303.0471535866202,
-        354.2881776680789
+        325.5056205715746,
+        459.13681582045564
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            8,
+            17
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.26.0",
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": [
+        "depth03_input.jpg",
+        "image"
+      ]
+    },
+    {
+      "id": 8,
+      "type": "ImageCompositeMasked",
+      "pos": [
+        1597.768975382267,
+        332.6964371281348
+      ],
+      "size": [
+        271.64609375,
+        146
       ],
       "flags": {},
       "order": 6,
       "mode": 0,
       "inputs": [
         {
-          "name": "images",
+          "name": "destination",
+          "type": "IMAGE",
+          "link": 17
+        },
+        {
+          "name": "source",
           "type": "IMAGE",
           "link": 18
+        },
+        {
+          "name": "mask",
+          "shape": 7,
+          "type": "MASK",
+          "link": 16
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            20
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.26.0",
+        "Node name for S&R": "ImageCompositeMasked"
+      },
+      "widgets_values": [
+        0,
+        0,
+        true
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 13,
+      "type": "SaveImage",
+      "pos": [
+        1904.5789033233184,
+        332.6964371281348
+      ],
+      "size": [
+        360.75008862304685,
+        495.060003692627
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 20
         }
       ],
       "outputs": [
@@ -283,14 +350,6 @@
       "BACKGROUND_REMOVAL"
     ],
     [
-      3,
-      1,
-      0,
-      4,
-      0,
-      "MASK"
-    ],
-    [
       8,
       2,
       0,
@@ -299,34 +358,50 @@
       "IMAGE"
     ],
     [
-      13,
-      1,
-      0,
-      10,
-      0,
-      "MASK"
-    ],
-    [
       15,
-      10,
+      1,
       0,
       11,
-      1,
+      0,
       "MASK"
     ],
     [
       16,
+      11,
+      0,
+      8,
+      2,
+      "MASK"
+    ],
+    [
+      17,
       2,
       0,
-      11,
+      8,
       0,
       "IMAGE"
     ],
     [
       18,
-      11,
+      10,
       0,
-      15,
+      8,
+      1,
+      "IMAGE"
+    ],
+    [
+      19,
+      12,
+      0,
+      10,
+      0,
+      "INT"
+    ],
+    [
+      20,
+      8,
+      0,
+      13,
       0,
       "IMAGE"
     ]
@@ -335,13 +410,17 @@
   "config": {},
   "extra": {
     "ds": {
-      "scale": 1,
+      "scale": 0.7513148009015778,
       "offset": [
-        -585.8257424834793,
-        -221.4257217325228
+        -431.4889771758615,
+        -4.5243700184477955
       ]
     },
-    "frontendVersion": "1.45.19"
+    "frontendVersion": "1.45.19",
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true
   },
   "version": 0.4
 }


### PR DESCRIPTION
## Summary

- Update the BiRefNet article in JA/EN/ZH with foreground cutout and background fill notes.
- Replace the existing BiRefNet workflow with a foreground cutout workflow that outputs an alpha image.
- Add a new `BiRefNet_fill.json` workflow for solid-color background fill.

## Notes

- The background fill workflow intentionally uses the inverted BiRefNet mask for `Image Composite Masked`, so the background area is replaced by the solid-color source image.
- The article links to the existing layer composite page for the compositing details.

## Checks

- `git diff --check`
- `npm run check`
- `npm run build`
- `npm run test:playwright`

## Advisory Warnings

- `npm run check` still reports existing advisory warnings:
  - 76 markdown link advisory issues
  - 22 icon `currentColor` advisory issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new workflow for filling removed backgrounds with a solid color after cutout.
  * Expanded the background removal workflow with clearer steps for keeping transparency and handling masks.

* **Documentation**
  * Updated the BiRefNet guides in multiple languages with refreshed images, dates, and more detailed step-by-step instructions.
  * Added clearer guidance for compositing results and working with layered backgrounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->