### PR TITLE
Update PiD workflows to v1.5

### DIFF
--- a/src/content/en/basic-workflows/pixeldit-pid.md
+++ b/src/content/en/basic-workflows/pixeldit-pid.md
@@ -6,7 +6,7 @@ slug: pixeldit-pid
 navId: pixeldit-pid
 title: "PixelDiT / PiD"
 created: 2026-06-09
-updated: 2026-06-09
+updated: 2026-07-29
 summary: "Image generation and high-resolution decoding with PixelDiT and PiD"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:
@@ -78,31 +78,31 @@ In short, you can use the generation ability of an existing model while avoiding
 
 - For Qwen-Image
 
-  - [pid_qwenimage_1024_to_4096_4step_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/diffusion_models/pid_qwenimage_1024_to_4096_4step_bf16.safetensors) (2.72 GB)
+  - [pid_1.5_qwenimage_1024_to_4096_4step_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/diffusion_models/pid_1.5_qwenimage_1024_to_4096_4step_bf16.safetensors) (2.8 GB)
 
 - For Flux.1 / Z-Image
 
   - [pid_flux1_512_to_2048_4step_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/diffusion_models/pid_flux1_512_to_2048_4step_bf16.safetensors) (2.72 GB)
-  - [pid_flux1_1024_to_4096_4step_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/diffusion_models/pid_flux1_1024_to_4096_4step_bf16.safetensors) (2.72 GB)
+  - [pid_1.5_flux1_1024_to_4096_4step_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/diffusion_models/pid_1.5_flux1_1024_to_4096_4step_bf16.safetensors) (2.8 GB)
 
 - For Flux.2
 
   - [pid_flux2_512_to_2048_4step_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/diffusion_models/pid_flux2_512_to_2048_4step_bf16.safetensors) (2.73 GB)
-  - [pid_flux2_1024_to_4096_4step_2606_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/diffusion_models/pid_flux2_1024_to_4096_4step_2606_bf16.safetensors) (2.73 GB)
+  - [pid_1.5_flux2_1024_to_4096_4step_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/diffusion_models/pid_1.5_flux2_1024_to_4096_4step_bf16.safetensors) (2.8 GB)
 
 ```text
 📂ComfyUI/
 └── 📂models/
     └── 📂diffusion_models/
         ├── pid_sdxl_1024_to_4096_4step_bf16.safetensors
-        ├── pid_qwenimage_1024_to_4096_4step_bf16.safetensors
+        ├── pid_1.5_qwenimage_1024_to_4096_4step_bf16.safetensors
         ├── pid_flux1_512_to_2048_4step_bf16.safetensors
-        ├── pid_flux1_1024_to_4096_4step_bf16.safetensors
+        ├── pid_1.5_flux1_1024_to_4096_4step_bf16.safetensors
         ├── pid_flux2_512_to_2048_4step_bf16.safetensors
-        └── pid_flux2_1024_to_4096_4step_2606_bf16.safetensors
+        └── pid_1.5_flux2_1024_to_4096_4step_bf16.safetensors
 ```
 
-You do not need to install all of them. Place only the PiD model that matches the base model you use.
+> You do not need to install all of them. Place only the PiD model that matches the base model you use.
 
 ### Choosing a Model
 
@@ -117,13 +117,15 @@ There are two points to watch when choosing a PiD model.
   - It does not upscale automatically just because you choose the model. For `1024_to_4096`, pass a latent / output around 1024px to PiD, then set the parameters so that PiD outputs a 4096px image.
   - The aspect ratio is flexible as long as the rough resolution matches.
 
+---
+
 ### Z-Image-Turbo → PiD
 
 Let's decode a Z-Image-Turbo latent with PiD.
 
-![](https://gyazo.com/ffadadaad0731fe65418fde91d8214e0){gyazo=image}
+![](https://gyazo.com/1b9e2dab2979aaafb65acc6e207c5948){gyazo=image}
 
-[](/workflows/basic-workflows/pixeldit-pid/Z-Image-Turbo_to_PiD_4k.json)
+[](/workflows/basic-workflows/pixeldit-pid/Z-Image-Turbo_to_PiD1.5_4k.json)
 
 - 🟦 The upper-left part is a normal [Z-Image-Turbo](/en/basic-workflows/z-image-turbo/) workflow.
   - 🟩 Instead of sending the output latent to VAE Decode, connect it to PixelDiT's `PiD Conditioning`.
@@ -133,31 +135,31 @@ Let's decode a Z-Image-Turbo latent with PiD.
 - The `Context Windows (Manual)` node is for tiling.
   Use it when you run into OOM, or when tall / wide images come out rough.
 
+---
+
 ### Upscaling Any Image
 
 What gets passed to `PiD Conditioning` is just a latent.
 
 So the previous step does not need to be text2image. You can VAE Encode any image you like, pass it to PiD, and use it like an upscaler.
 
-![](https://gyazo.com/1d83eec4daa183467327ed1d3a5b3461){gyazo=image}
+This example uses the PiD 1.5 model for Flux.2 with `flux2-vae.safetensors`.
 
-[](/workflows/basic-workflows/pixeldit-pid/PiD_flux1_4x_enhance.json)
-
-- Resize the input image to around 1M pixels, with dimensions that are multiples of 16
-- Get the resized height and width, multiply them by 4, and use those values as the PiD output size
-
-Each PiD model expects a matching VAE, so you need to Encode with the VAE that matches the PiD model.
-
-It is tempting to use the newer Flux.2 VAE, but it changes the colors quite a lot. Here, the more stable `Flux.1 PiD` + `ae.safetensors` combination is used.
-
-- [ae.safetensors](https://huggingface.co/Comfy-Org/z_image_turbo/blob/main/split_files/vae/ae.safetensors) (335 MB)
+- [flux2-vae.safetensors](https://huggingface.co/Comfy-Org/vae-text-encorder-for-flux-klein-9b/blob/main/split_files/vae/flux2-vae.safetensors) (336 MB)
 
 ```text
 📂ComfyUI/
 └── 📂models/
     └── 📂vae/
-        └── ae.safetensors
+        └── flux2-vae.safetensors
 ```
+
+![](https://gyazo.com/f501e4a19e295189ca8fdc8d509eb589){gyazo=image}
+
+[](/workflows/basic-workflows/pixeldit-pid/PiD1.5_flux2_4x_enhance.json)
+
+- Resize the input image to around 1M pixels, with dimensions that are multiples of 16
+- Get the resized height and width, multiply them by 4, and use those values as the PiD output size
 
 > What this does is essentially redrawing, so it is more of an enhance step than a normal upscaler.<br>
 > It is not well suited when faithful reproduction is required.

--- a/src/content/ja/basic-workflows/pixeldit-pid.md
+++ b/src/content/ja/basic-workflows/pixeldit-pid.md
@@ -6,7 +6,7 @@ slug: pixeldit-pid
 navId: pixeldit-pid
 title: "PixelDiT / PiD"
 created: 2026-06-09
-updated: 2026-06-09
+updated: 2026-07-29
 summary: "PixelDiT と PiD を使った画像生成・高解像度デコード"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:
@@ -78,31 +78,31 @@ PiD では、その latent を PixelDiT に渡して、画像への復元と拡�
 
 - Qwen-Image 用
 
-  - [pid_qwenimage_1024_to_4096_4step_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/diffusion_models/pid_qwenimage_1024_to_4096_4step_bf16.safetensors) (2.72 GB)
+  - [pid_1.5_qwenimage_1024_to_4096_4step_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/diffusion_models/pid_1.5_qwenimage_1024_to_4096_4step_bf16.safetensors) (2.8 GB)
 
 - Flux.1 / Z-Image 用
 
   - [pid_flux1_512_to_2048_4step_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/diffusion_models/pid_flux1_512_to_2048_4step_bf16.safetensors) (2.72 GB)
-  - [pid_flux1_1024_to_4096_4step_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/diffusion_models/pid_flux1_1024_to_4096_4step_bf16.safetensors) (2.72 GB)
+  - [pid_1.5_flux1_1024_to_4096_4step_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/diffusion_models/pid_1.5_flux1_1024_to_4096_4step_bf16.safetensors) (2.8 GB)
 
 - Flux.2 用
 
   - [pid_flux2_512_to_2048_4step_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/diffusion_models/pid_flux2_512_to_2048_4step_bf16.safetensors) (2.73 GB)
-  - [pid_flux2_1024_to_4096_4step_2606_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/diffusion_models/pid_flux2_1024_to_4096_4step_2606_bf16.safetensors) (2.73 GB)
+  - [pid_1.5_flux2_1024_to_4096_4step_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/diffusion_models/pid_1.5_flux2_1024_to_4096_4step_bf16.safetensors) (2.8 GB)
 
 ```text
 📂ComfyUI/
 └── 📂models/
     └── 📂diffusion_models/
         ├── pid_sdxl_1024_to_4096_4step_bf16.safetensors
-        ├── pid_qwenimage_1024_to_4096_4step_bf16.safetensors
+        ├── pid_1.5_qwenimage_1024_to_4096_4step_bf16.safetensors
         ├── pid_flux1_512_to_2048_4step_bf16.safetensors
-        ├── pid_flux1_1024_to_4096_4step_bf16.safetensors
+        ├── pid_1.5_flux1_1024_to_4096_4step_bf16.safetensors
         ├── pid_flux2_512_to_2048_4step_bf16.safetensors
-        └── pid_flux2_1024_to_4096_4step_2606_bf16.safetensors
+        └── pid_1.5_flux2_1024_to_4096_4step_bf16.safetensors
 ```
 
-すべて入れる必要はありません。使うベースモデルに対応した PiD だけ配置します。
+> すべて入れる必要はありません。使うベースモデルに対応した PiD だけ配置します。
 
 ### モデルの選び方
 
@@ -117,13 +117,15 @@ PiD では、その latent を PixelDiT に渡して、画像への復元と拡�
   - これを使えば勝手に拡大されるわけではなく、たとえば `1024_to_4096` なら、1024px 相当の latent / 出力を PiD に渡し、4096px の画像が出力されるようにパラメータを設定します。
   - 大まかな解像度があっていればアスペクト比は自由です。
 
+---
+
 ### Z-Image-Turbo → PiD
 
 Z-Image-Turbo の latent を、PiD でデコードしてみましょう。
 
-![](https://gyazo.com/ffadadaad0731fe65418fde91d8214e0){gyazo=image}
+![](https://gyazo.com/1b9e2dab2979aaafb65acc6e207c5948){gyazo=image}
 
-[](/workflows/basic-workflows/pixeldit-pid/Z-Image-Turbo_to_PiD_4k.json)
+[](/workflows/basic-workflows/pixeldit-pid/Z-Image-Turbo_to_PiD1.5_4k.json)
 
 - 🟦 左上は通常の [Z-Image-Turbo](/ja/basic-workflows/z-image-turbo/) workflow です。
   - 🟩 出力された latent は VAE Decode せず、PixelDiT 側の `PiD Conditioning` に繋ぎます。
@@ -133,31 +135,31 @@ Z-Image-Turbo の latent を、PiD でデコードしてみましょう。
 - `Context Windows (Manual)` ノードは、いわゆるタイリング用です。
   OOM する場合や、縦長・横長の画像で出力が荒れる場合に使います。
 
+---
+
 ### 任意の画像をアップスケール
 
 `PiD Conditioning` に渡しているのは、ただの latent です。
 
 そのため、前段でわざわざ text2image をしなくても、好きな画像を一度 VAE Encode して PiD に渡せば、アップスケーラーのように使うこともできます。
 
-![](https://gyazo.com/1d83eec4daa183467327ed1d3a5b3461){gyazo=image}
+今回は、PiD 1.5 の Flux.2 用モデルと `flux2-vae.safetensors` を使います。
 
-[](/workflows/basic-workflows/pixeldit-pid/PiD_flux1_4x_enhance.json)
-
-- 入力画像を 1M ピクセル相当、かつ 16 の倍数になるようにリサイズ
-- リサイズ後の高さと幅を取得し、4 倍した値を PiD 側の出力サイズに使用
-
-PiD モデルごとに対応する VAE が違うため、PiD モデルに合った VAE で Encode する必要があります。
-
-新しい Flux.2 VAE を使いたくなりますが、色が大きく変わってしまうため、ここでは安定している `Flux.1用PiD` + `ae.safetensors` の組み合わせにしています。
-
-- [ae.safetensors](https://huggingface.co/Comfy-Org/z_image_turbo/blob/main/split_files/vae/ae.safetensors) (335 MB)
+- [flux2-vae.safetensors](https://huggingface.co/Comfy-Org/vae-text-encorder-for-flux-klein-9b/blob/main/split_files/vae/flux2-vae.safetensors) (336 MB)
 
 ```text
 📂ComfyUI/
 └── 📂models/
     └── 📂vae/
-        └── ae.safetensors
+        └── flux2-vae.safetensors
 ```
+
+![](https://gyazo.com/f501e4a19e295189ca8fdc8d509eb589){gyazo=image}
+
+[](/workflows/basic-workflows/pixeldit-pid/PiD1.5_flux2_4x_enhance.json)
+
+- 入力画像を 1M ピクセル相当、かつ 16 の倍数になるようにリサイズ
+- リサイズ後の高さと幅を取得し、4 倍した値を PiD 側の出力サイズに使用
 
 > やっていることは本質的には描き直しなので、アップスケーラーというよりエンハンスです。  
 > 忠実な再現が必要な用途にはあまり向きません。

--- a/src/content/zh/basic-workflows/pixeldit-pid.md
+++ b/src/content/zh/basic-workflows/pixeldit-pid.md
@@ -6,7 +6,7 @@ slug: pixeldit-pid
 navId: pixeldit-pid
 title: "PixelDiT / PiD"
 created: 2026-06-09
-updated: 2026-06-09
+updated: 2026-07-29
 summary: "使用 PixelDiT 和 PiD 进行图像生成与高分辨率解码"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:
@@ -78,31 +78,31 @@ PiD 则是把这个 latent 交给 PixelDiT，让图像还原和放大一起完�
 
 - Qwen-Image 用
 
-  - [pid_qwenimage_1024_to_4096_4step_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/diffusion_models/pid_qwenimage_1024_to_4096_4step_bf16.safetensors) (2.72 GB)
+  - [pid_1.5_qwenimage_1024_to_4096_4step_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/diffusion_models/pid_1.5_qwenimage_1024_to_4096_4step_bf16.safetensors) (2.8 GB)
 
 - Flux.1 / Z-Image 用
 
   - [pid_flux1_512_to_2048_4step_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/diffusion_models/pid_flux1_512_to_2048_4step_bf16.safetensors) (2.72 GB)
-  - [pid_flux1_1024_to_4096_4step_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/diffusion_models/pid_flux1_1024_to_4096_4step_bf16.safetensors) (2.72 GB)
+  - [pid_1.5_flux1_1024_to_4096_4step_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/diffusion_models/pid_1.5_flux1_1024_to_4096_4step_bf16.safetensors) (2.8 GB)
 
 - Flux.2 用
 
   - [pid_flux2_512_to_2048_4step_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/diffusion_models/pid_flux2_512_to_2048_4step_bf16.safetensors) (2.73 GB)
-  - [pid_flux2_1024_to_4096_4step_2606_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/diffusion_models/pid_flux2_1024_to_4096_4step_2606_bf16.safetensors) (2.73 GB)
+  - [pid_1.5_flux2_1024_to_4096_4step_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/diffusion_models/pid_1.5_flux2_1024_to_4096_4step_bf16.safetensors) (2.8 GB)
 
 ```text
 📂ComfyUI/
 └── 📂models/
     └── 📂diffusion_models/
         ├── pid_sdxl_1024_to_4096_4step_bf16.safetensors
-        ├── pid_qwenimage_1024_to_4096_4step_bf16.safetensors
+        ├── pid_1.5_qwenimage_1024_to_4096_4step_bf16.safetensors
         ├── pid_flux1_512_to_2048_4step_bf16.safetensors
-        ├── pid_flux1_1024_to_4096_4step_bf16.safetensors
+        ├── pid_1.5_flux1_1024_to_4096_4step_bf16.safetensors
         ├── pid_flux2_512_to_2048_4step_bf16.safetensors
-        └── pid_flux2_1024_to_4096_4step_2606_bf16.safetensors
+        └── pid_1.5_flux2_1024_to_4096_4step_bf16.safetensors
 ```
 
-不需要全部放进去。只放和使用的基础模型对应的 PiD 就可以。
+> 不需要全部放进去。只放和使用的基础模型对应的 PiD 就可以。
 
 ### 模型的选择
 
@@ -117,13 +117,15 @@ PiD 则是把这个 latent 交给 PixelDiT，让图像还原和放大一起完�
   - 并不是选了这个模型就会自动放大。比如 `1024_to_4096`，需要把 1024px 左右的 latent / 输出交给 PiD，并设置参数，让 PiD 输出 4096px 的图像。
   - 大致分辨率对上即可，宽高比可以自由调整。
 
+---
+
 ### Z-Image-Turbo → PiD
 
 试着用 PiD 解码 Z-Image-Turbo 的 latent。
 
-![](https://gyazo.com/ffadadaad0731fe65418fde91d8214e0){gyazo=image}
+![](https://gyazo.com/1b9e2dab2979aaafb65acc6e207c5948){gyazo=image}
 
-[](/workflows/basic-workflows/pixeldit-pid/Z-Image-Turbo_to_PiD_4k.json)
+[](/workflows/basic-workflows/pixeldit-pid/Z-Image-Turbo_to_PiD1.5_4k.json)
 
 - 🟦 左上是普通的 [Z-Image-Turbo](/zh/basic-workflows/z-image-turbo/) workflow。
   - 🟩 输出的 latent 不走 VAE Decode，而是连接到 PixelDiT 侧的 `PiD Conditioning`。
@@ -133,31 +135,31 @@ PiD 则是把这个 latent 交给 PixelDiT，让图像还原和放大一起完�
 - `Context Windows (Manual)` 节点用于 tiling。
   OOM 时，或者纵长 / 横长图像输出变粗糙时使用。
 
+---
+
 ### 放大任意图像
 
 传给 `PiD Conditioning` 的，只是普通的 latent。
 
 因此，前面不一定要专门做 text2image。把任意图像先 VAE Encode，再交给 PiD，就可以像 upscaler 一样使用。
 
-![](https://gyazo.com/1d83eec4daa183467327ed1d3a5b3461){gyazo=image}
+这里使用面向 Flux.2 的 PiD 1.5 模型和 `flux2-vae.safetensors`。
 
-[](/workflows/basic-workflows/pixeldit-pid/PiD_flux1_4x_enhance.json)
-
-- 将输入图像 resize 到约 1M 像素，并让尺寸成为 16 的倍数
-- 取得 resize 后的高和宽，把它们乘以 4，作为 PiD 侧的输出尺寸
-
-每个 PiD 模型对应的 VAE 不同，因此需要用和 PiD 模型匹配的 VAE 来 Encode。
-
-可能会想使用新的 Flux.2 VAE，但颜色会变化很大。这里使用更稳定的 `Flux.1 用 PiD` + `ae.safetensors` 组合。
-
-- [ae.safetensors](https://huggingface.co/Comfy-Org/z_image_turbo/blob/main/split_files/vae/ae.safetensors) (335 MB)
+- [flux2-vae.safetensors](https://huggingface.co/Comfy-Org/vae-text-encorder-for-flux-klein-9b/blob/main/split_files/vae/flux2-vae.safetensors) (336 MB)
 
 ```text
 📂ComfyUI/
 └── 📂models/
     └── 📂vae/
-        └── ae.safetensors
+        └── flux2-vae.safetensors
 ```
+
+![](https://gyazo.com/f501e4a19e295189ca8fdc8d509eb589){gyazo=image}
+
+[](/workflows/basic-workflows/pixeldit-pid/PiD1.5_flux2_4x_enhance.json)
+
+- 将输入图像 resize 到约 1M 像素，并让尺寸成为 16 的倍数
+- 取得 resize 后的高和宽，把它们乘以 4，作为 PiD 侧的输出尺寸
 
 > 本质上做的是重新描绘，所以与其说是 upscaler，不如说是 enhance。<br>
 > 不太适合需要忠实再现的用途。

--- a/src/workflows/basic-workflows/pixeldit-pid/PiD1.5_flux2_4x_enhance.json
+++ b/src/workflows/basic-workflows/pixeldit-pid/PiD1.5_flux2_4x_enhance.json
@@ -1,0 +1,1102 @@
+{
+  "id": "1aa3b166-1861-429f-92ae-7ee12e64ab01",
+  "revision": 0,
+  "last_node_id": 96,
+  "last_link_id": 147,
+  "nodes": [
+    {
+      "id": 60,
+      "type": "CLIPLoader",
+      "pos": [
+        178.4554950121201,
+        811.9490780397168
+      ],
+      "size": [
+        301.3524169921875,
+        106
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "slot_index": 0,
+          "links": [
+            104,
+            109
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPLoader",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "gemma_2_2b_it_elm_bf16.safetensors",
+        "pixeldit",
+        "default"
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 63,
+      "type": "CLIPTextEncode",
+      "pos": [
+        538.1873071000066,
+        694.9903029515484
+      ],
+      "size": [
+        361.1895922851561,
+        152.373631591797
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 109
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            112
+          ]
+        }
+      ],
+      "title": "CLIP Text Encode (Positive Prompt)",
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        ""
+      ]
+    },
+    {
+      "id": 70,
+      "type": "ComfyMathExpression",
+      "pos": [
+        671.8070430075916,
+        989.4245396947579
+      ],
+      "size": [
+        210,
+        128
+      ],
+      "flags": {},
+      "order": 15,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "a",
+          "name": "values.a",
+          "type": "FLOAT,INT,BOOLEAN",
+          "link": 138
+        },
+        {
+          "label": "b",
+          "name": "values.b",
+          "shape": 7,
+          "type": "FLOAT,INT,BOOLEAN",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "FLOAT",
+          "type": "FLOAT",
+          "links": null
+        },
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            121
+          ]
+        },
+        {
+          "name": "BOOL",
+          "type": "BOOLEAN",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ComfyMathExpression"
+      },
+      "widgets_values": [
+        "a * 4"
+      ]
+    },
+    {
+      "id": 74,
+      "type": "ComfyMathExpression",
+      "pos": [
+        671.926902524347,
+        1173.415179658996
+      ],
+      "size": [
+        210,
+        128
+      ],
+      "flags": {},
+      "order": 16,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "a",
+          "name": "values.a",
+          "type": "FLOAT,INT,BOOLEAN",
+          "link": 139
+        },
+        {
+          "label": "b",
+          "name": "values.b",
+          "shape": 7,
+          "type": "FLOAT,INT,BOOLEAN",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "FLOAT",
+          "type": "FLOAT",
+          "links": null
+        },
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            122
+          ]
+        },
+        {
+          "name": "BOOL",
+          "type": "BOOLEAN",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ComfyMathExpression"
+      },
+      "widgets_values": [
+        "a * 4"
+      ]
+    },
+    {
+      "id": 62,
+      "type": "VAELoader",
+      "pos": [
+        1360.9976510179852,
+        555.9717618776077
+      ],
+      "size": [
+        235.80000000000018,
+        58
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "slot_index": 0,
+          "links": [
+            103
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAELoader",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "pixel_space"
+      ]
+    },
+    {
+      "id": 82,
+      "type": "ResizeImageMaskNode",
+      "pos": [
+        -187.68646898516153,
+        1095.0166207447435
+      ],
+      "size": [
+        266.5849202168248,
+        106
+      ],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input",
+          "type": "IMAGE,MASK",
+          "link": 134
+        }
+      ],
+      "outputs": [
+        {
+          "name": "resized",
+          "type": "IMAGE",
+          "links": [
+            135
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ResizeImageMaskNode"
+      },
+      "widgets_values": [
+        "scale total pixels",
+        1,
+        "nearest-exact"
+      ]
+    },
+    {
+      "id": 80,
+      "type": "VAEEncode",
+      "pos": [
+        407.88598227132763,
+        1095.0166207447435
+      ],
+      "size": [
+        170.05260120738637,
+        46
+      ],
+      "flags": {},
+      "order": 12,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "pixels",
+          "type": "IMAGE",
+          "link": 136
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 132
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            133
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAEEncode"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 58,
+      "type": "CLIPTextEncode",
+      "pos": [
+        540.3078029573284,
+        910.6321261399594
+      ],
+      "size": [
+        419.26959228515625,
+        107.08506774902344
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 104
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            107
+          ]
+        }
+      ],
+      "title": "CLIP Text Encode (Negative Prompt)",
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        ""
+      ]
+    },
+    {
+      "id": 84,
+      "type": "GetImageSize",
+      "pos": [
+        409.91468906546555,
+        1197.5924621383035
+      ],
+      "size": [
+        210,
+        136
+      ],
+      "flags": {},
+      "order": 13,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 137
+        }
+      ],
+      "outputs": [
+        {
+          "name": "width",
+          "type": "INT",
+          "links": [
+            138
+          ]
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "links": [
+            139
+          ]
+        },
+        {
+          "name": "batch_size",
+          "type": "INT",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "GetImageSize"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 65,
+      "type": "SaveImage",
+      "pos": [
+        1826.4226403881014,
+        674.4492063356142
+      ],
+      "size": [
+        644.1825674446068,
+        806.9942591157356
+      ],
+      "flags": {},
+      "order": 20,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 110
+        }
+      ],
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.75"
+      },
+      "widgets_values": [
+        "ComfyUI"
+      ]
+    },
+    {
+      "id": 64,
+      "type": "EmptyChromaRadianceLatentImage",
+      "pos": [
+        914.3139120643391,
+        987.6451858178366
+      ],
+      "size": [
+        300.8609375,
+        106
+      ],
+      "flags": {},
+      "order": 17,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "width",
+          "type": "INT",
+          "widget": {
+            "name": "width"
+          },
+          "link": 121
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "widget": {
+            "name": "height"
+          },
+          "link": 122
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            108
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "EmptyChromaRadianceLatentImage"
+      },
+      "widgets_values": [
+        896,
+        1152,
+        1
+      ]
+    },
+    {
+      "id": 90,
+      "type": "ContextWindowsManual",
+      "pos": [
+        914.3048544471521,
+        326.3776092603588
+      ],
+      "size": [
+        299.9609375,
+        322
+      ],
+      "flags": {},
+      "order": 11,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 144
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            145
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ContextWindowsManual"
+      },
+      "widgets_values": [
+        1536,
+        384,
+        "standard_static",
+        1,
+        false,
+        "pyramid",
+        0,
+        false,
+        "",
+        false,
+        "",
+        true
+      ]
+    },
+    {
+      "id": 77,
+      "type": "ModelSamplingSD3",
+      "pos": [
+        647.074781051246,
+        326.3776092603588
+      ],
+      "size": [
+        234.02274434806372,
+        58
+      ],
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 125
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            144
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ModelSamplingSD3"
+      },
+      "widgets_values": [
+        4
+      ]
+    },
+    {
+      "id": 67,
+      "type": "PiDConditioning",
+      "pos": [
+        944.2657919471521,
+        694.9903029515484
+      ],
+      "size": [
+        270,
+        102
+      ],
+      "flags": {},
+      "order": 14,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 112
+        },
+        {
+          "name": "latent",
+          "type": "LATENT",
+          "link": 133
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            113
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "PiDConditioning"
+      },
+      "widgets_values": [
+        "flux",
+        0
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 57,
+      "type": "VAEDecode",
+      "pos": [
+        1635.4756905687632,
+        674.4492063356142
+      ],
+      "size": [
+        157.56002807617188,
+        46
+      ],
+      "flags": {},
+      "order": 19,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 102
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 103
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [
+            110
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAEDecode",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 83,
+      "type": "ResizeImageMaskNode",
+      "pos": [
+        106.84934568668905,
+        1095.0166207447435
+      ],
+      "size": [
+        266.5849202168248,
+        106
+      ],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input",
+          "type": "IMAGE,MASK",
+          "link": 135
+        }
+      ],
+      "outputs": [
+        {
+          "name": "resized",
+          "type": "IMAGE",
+          "links": [
+            136,
+            137
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ResizeImageMaskNode"
+      },
+      "widgets_values": [
+        "scale to multiple",
+        16,
+        "nearest-exact"
+      ]
+    },
+    {
+      "id": 79,
+      "type": "LoadImage",
+      "pos": [
+        -532.4361549440936,
+        1095.0166207447435
+      ],
+      "size": [
+        316.7987915039063,
+        467.0000366210936
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            134
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": [
+        "viewfilename=ComfyUI_temp_rpijz_00022_.png",
+        "image"
+      ]
+    },
+    {
+      "id": 81,
+      "type": "VAELoader",
+      "pos": [
+        85.79355151979729,
+        989.5464055577053
+      ],
+      "size": [
+        287.64071438371656,
+        58
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "slot_index": 0,
+          "links": [
+            132
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAELoader",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "flux2-vae.safetensors"
+      ],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 59,
+      "type": "UNETLoader",
+      "pos": [
+        313.05994271638855,
+        326.3776092603588
+      ],
+      "size": [
+        305.3782043457031,
+        82
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            125
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "UNETLoader",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "pid_1.5_flux2_1024_to_4096_4step_bf16.safetensors",
+        "default"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 61,
+      "type": "KSampler",
+      "pos": [
+        1281.7976510179856,
+        674.4492063356142
+      ],
+      "size": [
+        315,
+        262
+      ],
+      "flags": {},
+      "order": 18,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 145
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 113
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 107
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 108
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "slot_index": 0,
+          "links": [
+            102
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "KSampler",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        1234,
+        "fixed",
+        4,
+        1,
+        "lcm",
+        "simple",
+        1
+      ]
+    },
+    {
+      "id": 89,
+      "type": "MarkdownNote",
+      "pos": [
+        -135.8324089797664,
+        326.3776092603588
+      ],
+      "size": [
+        414.3873929207863,
+        299.6311117170049
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "## models\n\n* diffusion_models\n\n  *  [pid_1.5_flux2_1024_to_4096_4step_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/diffusion_models/pid_1.5_flux2_1024_to_4096_4step_bf16.safetensors) (2.8 GB)\n\n* text_encoders\n\n  * [gemma_2_2b_it_elm_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/text_encoders/gemma_2_2b_it_elm_bf16.safetensors) (5.23 GB)\n\n* vae\n\n  * [flux2-vae.safetensors](https://huggingface.co/Comfy-Org/vae-text-encorder-for-flux-klein-9b/blob/main/split_files/vae/flux2-vae.safetensors) (336 MB)\n\n\n```text\n📂ComfyUI/\n└── 📂models/\n    ├── 📂diffusion_models/\n    │    └── pid_1.5_flux2_1024_to_4096_4step_bf16.safetensors\n    ├── 📂text_encoders/\n    │    └── gemma_2_2b_it_elm_bf16.safetensors\n    └── 📂vae/\n          └── flux2-vae.safetensors\n\n```"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    }
+  ],
+  "links": [
+    [
+      102,
+      61,
+      0,
+      57,
+      0,
+      "LATENT"
+    ],
+    [
+      103,
+      62,
+      0,
+      57,
+      1,
+      "VAE"
+    ],
+    [
+      104,
+      60,
+      0,
+      58,
+      0,
+      "CLIP"
+    ],
+    [
+      107,
+      58,
+      0,
+      61,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      108,
+      64,
+      0,
+      61,
+      3,
+      "LATENT"
+    ],
+    [
+      109,
+      60,
+      0,
+      63,
+      0,
+      "CLIP"
+    ],
+    [
+      110,
+      57,
+      0,
+      65,
+      0,
+      "IMAGE"
+    ],
+    [
+      112,
+      63,
+      0,
+      67,
+      0,
+      "CONDITIONING"
+    ],
+    [
+      113,
+      67,
+      0,
+      61,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      121,
+      70,
+      1,
+      64,
+      0,
+      "INT"
+    ],
+    [
+      122,
+      74,
+      1,
+      64,
+      1,
+      "INT"
+    ],
+    [
+      125,
+      59,
+      0,
+      77,
+      0,
+      "MODEL"
+    ],
+    [
+      132,
+      81,
+      0,
+      80,
+      1,
+      "VAE"
+    ],
+    [
+      133,
+      80,
+      0,
+      67,
+      1,
+      "LATENT"
+    ],
+    [
+      134,
+      79,
+      0,
+      82,
+      0,
+      "IMAGE"
+    ],
+    [
+      135,
+      82,
+      0,
+      83,
+      0,
+      "IMAGE"
+    ],
+    [
+      136,
+      83,
+      0,
+      80,
+      0,
+      "IMAGE"
+    ],
+    [
+      137,
+      83,
+      0,
+      84,
+      0,
+      "IMAGE"
+    ],
+    [
+      138,
+      84,
+      0,
+      70,
+      0,
+      "INT"
+    ],
+    [
+      139,
+      84,
+      1,
+      74,
+      0,
+      "INT"
+    ],
+    [
+      144,
+      77,
+      0,
+      90,
+      0,
+      "MODEL"
+    ],
+    [
+      145,
+      90,
+      0,
+      61,
+      0,
+      "MODEL"
+    ]
+  ],
+  "groups": [
+    {
+      "id": 2,
+      "title": "Pid_1024→4096",
+      "bounding": [
+        -554.3908824317602,
+        238.6952183841798,
+        3081.2835698845024,
+        1345.6484688397118
+      ],
+      "color": "#8A8",
+      "flags": {}
+    }
+  ],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.4736244074476708,
+      "offset": [
+        720.6286821401363,
+        117.25112206166943
+      ]
+    },
+    "frontendVersion": "1.47.10",
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true
+  },
+  "version": 0.4
+}

--- a/src/workflows/basic-workflows/pixeldit-pid/Z-Image-Turbo_to_PiD1.5_4k.json
+++ b/src/workflows/basic-workflows/pixeldit-pid/Z-Image-Turbo_to_PiD1.5_4k.json
@@ -1,0 +1,1421 @@
+{
+  "id": "d8034549-7e0a-40f1-8c2e-de3ffc6f1cae",
+  "revision": 0,
+  "last_node_id": 81,
+  "last_link_id": 134,
+  "nodes": [
+    {
+      "id": 38,
+      "type": "CLIPLoader",
+      "pos": [
+        32.131015771484385,
+        312.74468994140625
+      ],
+      "size": [
+        301.3524169921875,
+        106
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "slot_index": 0,
+          "links": [
+            74,
+            75
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPLoader",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "qwen_3_4b.safetensors",
+        "lumina2",
+        "default"
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 7,
+      "type": "CLIPTextEncode",
+      "pos": [
+        390.84235000000007,
+        405.392333984375
+      ],
+      "size": [
+        418.3189392089844,
+        107.08506774902344
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 75
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            52
+          ]
+        }
+      ],
+      "title": "CLIP Text Encode (Negative Prompt)",
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        ""
+      ]
+    },
+    {
+      "id": 54,
+      "type": "ModelSamplingAuraFlow",
+      "pos": [
+        579.7813758789064,
+        53.0477294921875
+      ],
+      "size": [
+        230.33058166503906,
+        58
+      ],
+      "flags": {},
+      "order": 17,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 99
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            100
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ModelSamplingAuraFlow",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.49"
+      },
+      "widgets_values": [
+        3.1
+      ]
+    },
+    {
+      "id": 55,
+      "type": "MarkdownNote",
+      "pos": [
+        -151.24897385253908,
+        -13.402286529541016
+      ],
+      "size": [
+        349.13103718118725,
+        214.5148968572393
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "## models\n- [z_image_turbo_bf16.safetensors](https://huggingface.co/Comfy-Org/z_image_turbo/blob/main/split_files/diffusion_models/z_image_turbo_bf16.safetensors)\n- [qwen_3_4b.safetensors](https://huggingface.co/Comfy-Org/z_image_turbo/blob/main/split_files/text_encoders/qwen_3_4b.safetensors)\n- [ae.safetensors](https://huggingface.co/Comfy-Org/z_image_turbo/blob/main/split_files/vae/ae.safetensors)\n\n```\n📂ComfyUI/\n└── 📂models/\n      ├── 📂diffusion_models/\n      │   └── z_image_turbo_bf16.safetensors\n      ├── 📂text_encoders/\n      │   └── qwen_3_4b.safetensors\n      └── 📂vae/\n           └── ae.safetensors\n```"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 57,
+      "type": "VAEDecode",
+      "pos": [
+        2059.9064044746965,
+        1212.0613014712694
+      ],
+      "size": [
+        157.56002807617188,
+        46
+      ],
+      "flags": {},
+      "order": 25,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 102
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 103
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [
+            110
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAEDecode",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 62,
+      "type": "VAELoader",
+      "pos": [
+        1785.4283649239185,
+        1093.5838570132628
+      ],
+      "size": [
+        235.80000000000018,
+        58
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "slot_index": 0,
+          "links": [
+            103
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAELoader",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "pixel_space"
+      ]
+    },
+    {
+      "id": 60,
+      "type": "CLIPLoader",
+      "pos": [
+        602.886208918055,
+        1349.5611731753713
+      ],
+      "size": [
+        301.3524169921875,
+        106
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "slot_index": 0,
+          "links": [
+            104,
+            109
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPLoader",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "gemma_2_2b_it_elm_bf16.safetensors",
+        "pixeldit",
+        "default"
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 58,
+      "type": "CLIPTextEncode",
+      "pos": [
+        962.6180210059409,
+        1452.9092950777112
+      ],
+      "size": [
+        419.26959228515625,
+        107.08506774902344
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 11,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 104
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            107
+          ]
+        }
+      ],
+      "title": "CLIP Text Encode (Negative Prompt)",
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        ""
+      ]
+    },
+    {
+      "id": 63,
+      "type": "CLIPTextEncode",
+      "pos": [
+        962.6180210059409,
+        1232.6023980872037
+      ],
+      "size": [
+        361.1895922851561,
+        152.373631591797
+      ],
+      "flags": {},
+      "order": 12,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 109
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            112
+          ]
+        }
+      ],
+      "title": "CLIP Text Encode (Positive Prompt)",
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        ""
+      ]
+    },
+    {
+      "id": 70,
+      "type": "ComfyMathExpression",
+      "pos": [
+        1095.328699296338,
+        1510.6730178870523
+      ],
+      "size": [
+        210,
+        128
+      ],
+      "flags": {},
+      "order": 13,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "a",
+          "name": "values.a",
+          "type": "FLOAT,INT,BOOLEAN",
+          "link": 128
+        },
+        {
+          "label": "b",
+          "name": "values.b",
+          "shape": 7,
+          "type": "FLOAT,INT,BOOLEAN",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "FLOAT",
+          "type": "FLOAT",
+          "links": null
+        },
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            121
+          ]
+        },
+        {
+          "name": "BOOL",
+          "type": "BOOLEAN",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ComfyMathExpression"
+      },
+      "widgets_values": [
+        "a * 4"
+      ]
+    },
+    {
+      "id": 74,
+      "type": "ComfyMathExpression",
+      "pos": [
+        1095.4485588130935,
+        1694.6636578512905
+      ],
+      "size": [
+        210,
+        128
+      ],
+      "flags": {},
+      "order": 15,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "a",
+          "name": "values.a",
+          "type": "FLOAT,INT,BOOLEAN",
+          "link": 131
+        },
+        {
+          "label": "b",
+          "name": "values.b",
+          "shape": 7,
+          "type": "FLOAT,INT,BOOLEAN",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "FLOAT",
+          "type": "FLOAT",
+          "links": null
+        },
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            122
+          ]
+        },
+        {
+          "name": "BOOL",
+          "type": "BOOLEAN",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ComfyMathExpression"
+      },
+      "widgets_values": [
+        "a * 4"
+      ]
+    },
+    {
+      "id": 61,
+      "type": "KSampler",
+      "pos": [
+        1706.228364923919,
+        1212.0613014712694
+      ],
+      "size": [
+        315,
+        262
+      ],
+      "flags": {},
+      "order": 24,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 134
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 113
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 107
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 108
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "slot_index": 0,
+          "links": [
+            102
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "KSampler",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        1234,
+        "fixed",
+        4,
+        1,
+        "lcm",
+        "simple",
+        1
+      ]
+    },
+    {
+      "id": 65,
+      "type": "SaveImage",
+      "pos": [
+        2250.8533542940327,
+        1212.0613014712694
+      ],
+      "size": [
+        666.7297467636986,
+        558.9757191157356
+      ],
+      "flags": {},
+      "order": 26,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 110
+        }
+      ],
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.75"
+      },
+      "widgets_values": [
+        "ComfyUI"
+      ]
+    },
+    {
+      "id": 39,
+      "type": "VAELoader",
+      "pos": [
+        953.7971717773437,
+        68.20164184570308
+      ],
+      "size": [
+        235.80000000000018,
+        58
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 4,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "slot_index": 0,
+          "links": [
+            76
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAELoader",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "ae.safetensors"
+      ],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 64,
+      "type": "EmptyChromaRadianceLatentImage",
+      "pos": [
+        1337.8355683530854,
+        1508.893664010131
+      ],
+      "size": [
+        300.8609375,
+        106
+      ],
+      "flags": {},
+      "order": 18,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "width",
+          "type": "INT",
+          "widget": {
+            "name": "width"
+          },
+          "link": 121
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "widget": {
+            "name": "height"
+          },
+          "link": 122
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            108
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "EmptyChromaRadianceLatentImage"
+      },
+      "widgets_values": [
+        896,
+        1152,
+        1
+      ]
+    },
+    {
+      "id": 8,
+      "type": "VAEDecode",
+      "pos": [
+        1228.2752113281254,
+        188.1918182373047
+      ],
+      "size": [
+        157.56002807617188,
+        46
+      ],
+      "flags": {},
+      "order": 21,
+      "mode": 4,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 35
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 76
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [
+            127
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAEDecode",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 53,
+      "type": "EmptySD3LatentImage",
+      "pos": [
+        573.1119422851564,
+        473.02593102293815
+      ],
+      "size": [
+        237,
+        106
+      ],
+      "flags": {},
+      "order": 14,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "width",
+          "type": "INT",
+          "widget": {
+            "name": "width"
+          },
+          "link": 129
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "widget": {
+            "name": "height"
+          },
+          "link": 130
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            98
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "EmptySD3LatentImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.49"
+      },
+      "widgets_values": [
+        1104,
+        1472,
+        1
+      ]
+    },
+    {
+      "id": 78,
+      "type": "PreviewImage",
+      "pos": [
+        1412.600554848482,
+        188.1918182373047
+      ],
+      "size": [
+        475.4999999999998,
+        310.8999999999998
+      ],
+      "flags": {},
+      "order": 23,
+      "mode": 4,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 127
+        }
+      ],
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "PreviewImage"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 67,
+      "type": "PiDConditioning",
+      "pos": [
+        1368.6965058530855,
+        1232.6023980872037
+      ],
+      "size": [
+        270,
+        102
+      ],
+      "flags": {},
+      "order": 22,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 112
+        },
+        {
+          "name": "latent",
+          "type": "LATENT",
+          "link": 111
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            113
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "PiDConditioning"
+      },
+      "widgets_values": [
+        "flux",
+        0
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 79,
+      "type": "ResolutionSelector",
+      "pos": [
+        259.561201016606,
+        493.48155615066963
+      ],
+      "size": [
+        270,
+        126
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "width",
+          "type": "INT",
+          "links": [
+            128,
+            129
+          ]
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "links": [
+            130,
+            131
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ResolutionSelector"
+      },
+      "widgets_values": [
+        "3:2 (Photo)",
+        1,
+        16
+      ]
+    },
+    {
+      "id": 59,
+      "type": "UNETLoader",
+      "pos": [
+        737.4906566223231,
+        863.9897043960142
+      ],
+      "size": [
+        305.3782043457031,
+        82
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            125
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "UNETLoader",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "pid_1.5_flux1_1024_to_4096_4step_bf16.safetensors",
+        "default"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 37,
+      "type": "UNETLoader",
+      "pos": [
+        243.49762343749995,
+        53.0477294921875
+      ],
+      "size": [
+        305.3782043457031,
+        82
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            99
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "UNETLoader",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "z_image_turbo_bf16.safetensors",
+        "default"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 77,
+      "type": "ModelSamplingSD3",
+      "pos": [
+        1071.5054949571797,
+        863.9897043960142
+      ],
+      "size": [
+        234.02274434806372,
+        58
+      ],
+      "flags": {},
+      "order": 16,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 125
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            132
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ModelSamplingSD3"
+      },
+      "widgets_values": [
+        4
+      ]
+    },
+    {
+      "id": 81,
+      "type": "ContextWindowsManual",
+      "pos": [
+        1338.7355683530855,
+        863.9897043960142
+      ],
+      "size": [
+        299.9609375,
+        322
+      ],
+      "flags": {},
+      "order": 19,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 132
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            134
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ContextWindowsManual"
+      },
+      "widgets_values": [
+        1536,
+        384,
+        "standard_static",
+        1,
+        false,
+        "pyramid",
+        0,
+        false,
+        "",
+        false,
+        "",
+        true
+      ]
+    },
+    {
+      "id": 3,
+      "type": "KSampler",
+      "pos": [
+        874.5971717773439,
+        188.1918182373047
+      ],
+      "size": [
+        315,
+        262
+      ],
+      "flags": {},
+      "order": 20,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 100
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 46
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 52
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 98
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "slot_index": 0,
+          "links": [
+            35,
+            111
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "KSampler",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        123,
+        "fixed",
+        8,
+        1,
+        "euler",
+        "simple",
+        1
+      ]
+    },
+    {
+      "id": 6,
+      "type": "CLIPTextEncode",
+      "pos": [
+        390.84235000000007,
+        186
+      ],
+      "size": [
+        419.26959228515625,
+        156.00363159179688
+      ],
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 74
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            46
+          ]
+        }
+      ],
+      "title": "CLIP Text Encode (Positive Prompt)",
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.33"
+      },
+      "widgets_values": [
+        "A single retro-style Japanese pudding in a handmade ceramic pedestal bowl, smooth golden custard with rich caramel sauce, topped with light cream, a small strawberry piece, and tiny leaves, set on a rustic wooden table beside wooden spoon, soft window light, natural and airy mood, warm earthy colors, shallow focus, tasteful Japanese cafe aesthetic, simple and elegant dessert photography, one pudding only, no extra desserts, no text, no logo, no watermark"
+      ]
+    },
+    {
+      "id": 66,
+      "type": "MarkdownNote",
+      "pos": [
+        319.0841671505862,
+        861.233126193333
+      ],
+      "size": [
+        391.4749836827225,
+        249.70306513499378
+      ],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "## models\n\n* diffusion_models\n\n  * [pid_flux1_512_to_2048_4step_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/diffusion_models/pid_flux1_512_to_2048_4step_bf16.safetensors) (2.72 GB)\n  *  [pid_1.5_flux1_1024_to_4096_4step_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/diffusion_models/pid_1.5_flux1_1024_to_4096_4step_bf16.safetensors) (2.8 GB)\n\n\n* text_encoders\n\n  * [gemma_2_2b_it_elm_bf16.safetensors](https://huggingface.co/Comfy-Org/PixelDiT/blob/main/text_encoders/gemma_2_2b_it_elm_bf16.safetensors) (5.23 GB)\n\n\n```text\n📂ComfyUI/\n└── 📂models/\n    ├── 📂diffusion_models/\n    │    ├── pid_flux1_512_to_2048_4step_bf16.safetensors\n    │    └── pid_1.5_flux1_1024_to_4096_4step_bf16.safetensors\n    └── 📂text_encoders/\n          └── gemma_2_2b_it_elm_bf16.safetensors\n```"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    }
+  ],
+  "links": [
+    [
+      35,
+      3,
+      0,
+      8,
+      0,
+      "LATENT"
+    ],
+    [
+      46,
+      6,
+      0,
+      3,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      52,
+      7,
+      0,
+      3,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      74,
+      38,
+      0,
+      6,
+      0,
+      "CLIP"
+    ],
+    [
+      75,
+      38,
+      0,
+      7,
+      0,
+      "CLIP"
+    ],
+    [
+      76,
+      39,
+      0,
+      8,
+      1,
+      "VAE"
+    ],
+    [
+      98,
+      53,
+      0,
+      3,
+      3,
+      "LATENT"
+    ],
+    [
+      99,
+      37,
+      0,
+      54,
+      0,
+      "MODEL"
+    ],
+    [
+      100,
+      54,
+      0,
+      3,
+      0,
+      "MODEL"
+    ],
+    [
+      102,
+      61,
+      0,
+      57,
+      0,
+      "LATENT"
+    ],
+    [
+      103,
+      62,
+      0,
+      57,
+      1,
+      "VAE"
+    ],
+    [
+      104,
+      60,
+      0,
+      58,
+      0,
+      "CLIP"
+    ],
+    [
+      107,
+      58,
+      0,
+      61,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      108,
+      64,
+      0,
+      61,
+      3,
+      "LATENT"
+    ],
+    [
+      109,
+      60,
+      0,
+      63,
+      0,
+      "CLIP"
+    ],
+    [
+      110,
+      57,
+      0,
+      65,
+      0,
+      "IMAGE"
+    ],
+    [
+      111,
+      3,
+      0,
+      67,
+      1,
+      "LATENT"
+    ],
+    [
+      112,
+      63,
+      0,
+      67,
+      0,
+      "CONDITIONING"
+    ],
+    [
+      113,
+      67,
+      0,
+      61,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      121,
+      70,
+      1,
+      64,
+      0,
+      "INT"
+    ],
+    [
+      122,
+      74,
+      1,
+      64,
+      1,
+      "INT"
+    ],
+    [
+      125,
+      59,
+      0,
+      77,
+      0,
+      "MODEL"
+    ],
+    [
+      127,
+      8,
+      0,
+      78,
+      0,
+      "IMAGE"
+    ],
+    [
+      128,
+      79,
+      0,
+      70,
+      0,
+      "INT"
+    ],
+    [
+      129,
+      79,
+      0,
+      53,
+      0,
+      "INT"
+    ],
+    [
+      130,
+      79,
+      1,
+      53,
+      1,
+      "INT"
+    ],
+    [
+      131,
+      79,
+      1,
+      74,
+      0,
+      "INT"
+    ],
+    [
+      132,
+      77,
+      0,
+      81,
+      0,
+      "MODEL"
+    ],
+    [
+      134,
+      81,
+      0,
+      61,
+      0,
+      "MODEL"
+    ]
+  ],
+  "groups": [
+    {
+      "id": 1,
+      "title": "Z-Image-Turbo",
+      "bounding": [
+        -161.24897385253908,
+        -83.40228652954102,
+        2064.456875764055,
+        806.5944331355984
+      ],
+      "color": "#3f789e",
+      "flags": {}
+    },
+    {
+      "id": 2,
+      "title": "Pid_1024→4096",
+      "bounding": [
+        290.6357989790571,
+        776.3072911794422,
+        2650.977159099303,
+        1063.3279125842512
+      ],
+      "color": "#8A8",
+      "flags": {}
+    }
+  ],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.5730855330116903,
+      "offset": [
+        623.4629309933692,
+        -519.8125339216135
+      ]
+    },
+    "frontendVersion": "1.47.10",
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true
+  },
+  "version": 0.4
+}


### PR DESCRIPTION
## What changed

- Updated the PixelDiT / PiD article to use the PiD 1.5 4K checkpoints for Qwen-Image, Flux.1, and Flux.2.
- Replaced the Z-Image-Turbo → PiD and arbitrary-image enhancement examples with PiD 1.5 workflows.
- Switched the enhancement example to the Flux.2 PiD model and `flux2-vae.safetensors`.
- Synchronized the Japanese, English, and Simplified Chinese pages, including dates, screenshots, model paths, and workflow links.

## Why

PiD 1.5 provides the current 1024-to-4096 checkpoints, while the article and downloadable examples still referenced the previous 4K model filenames and workflows.

## Impact

Readers now get matching model download instructions and reproducible PiD 1.5 workflow JSON files in all three supported languages.

## Validation

- `git diff --check`
- `npm run check`
- `npm run build`

All checks pass. Existing advisory link and icon notices remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PiD 1.5 workflows for converting Z-Image-Turbo outputs and enhancing images with Flux.2.
  * Added support for updated PiD 1.5 model variants, including QwenImage, Flux.1, and Flux.2.

* **Documentation**
  * Updated model download lists, directory examples, workflow references, images, and setup instructions across English, Japanese, and Chinese documentation.
  * Updated the upscaling guide to use `flux2-vae.safetensors` and the PiD 1.5 Flux.2 workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->