### PR TITLE
Refine Anima LLLite documentation

### DIFF
--- a/src/content/en/basic-workflows/anima.md
+++ b/src/content/en/basic-workflows/anima.md
@@ -42,6 +42,9 @@ It is one of the models drawing a lot of attention as a possible migration targe
 
   * [qwen_image_vae.safetensors](https://huggingface.co/circlestone-labs/Anima/blob/main/split_files/vae/qwen_image_vae.safetensors) (254 MB)
 
+> `anima-base-v1.0` is the untuned base model.
+> `anima-aesthetic-v1.1` is fine-tuned on high-quality images. If you just want to try generating images, this is generally the one to use.
+
 ```text
 📂ComfyUI/
 └── 📂models/
@@ -81,7 +84,7 @@ masterpiece, best quality, score_9, safe,
 
 ## Anima LLLite
 
-LLLite is something like a lightweight ControlNet developed by Kohya.
+ControlNet-LLLite is a lightweight ControlNet developed by kohya.
 
 ### Model Download
 
@@ -89,7 +92,7 @@ LLLite is something like a lightweight ControlNet developed by Kohya.
 
 Choose a suitable model for the control image you want to use.
 
-> Models marked `v2` were trained for Anima-Base v1.0. This example uses one with `anima-aesthetic-v1.1`. The others were trained for the older Anima Preview3, so they may be a little less effective.
+> Models marked `v2` were trained for Anima-Base v1.0. The others were trained for the older Anima Preview3, so they may be a little less effective.
 
 ```text
 📂ComfyUI/
@@ -104,6 +107,5 @@ Choose a suitable model for the control image you want to use.
 
 [](/workflows/basic-workflows/anima/anima-lllite-any-test-like-v2.json)
 
-`any-test-like-v2` combines several types of control, including rough sketches, line art, and grayscale images, in one model.
-
-Here, let's simply use an edge-detected image as the input.
+* `anima-lllite-any-test-like-v2` combines several types of control in a single model. It can use rough sketches or line art to guide the composition, or colorize grayscale images.
+* In this workflow, `Canny` extracts the outlines from the input image and uses them as the control image.

--- a/src/content/ja/basic-workflows/anima.md
+++ b/src/content/ja/basic-workflows/anima.md
@@ -84,7 +84,7 @@ masterpiece, best quality, score_9, safe,
 
 ## Anima LLLite
 
-LLLiteとは Kohya氏が開発した、軽量なControlNetのようなものです。
+ControlNet-LLLite は、kohya 氏が開発した軽量な ControlNet です。
 
 ### モデルのダウンロード
 
@@ -107,5 +107,5 @@ LLLiteとは Kohya氏が開発した、軽量なControlNetのようなもので�
 
 [](/workflows/basic-workflows/anima/anima-lllite-any-test-like-v2.json)
 
-* `any-test-like-v2` は、ラフや線画、グレースケール画像など、いくつかの制御をひとつにまとめたモデルです。
-* 今回は単にエッジ抽出したものを入力として、使ってみましょう。
+* `anima-lllite-any-test-like-v2` は、いくつかの制御をひとつにまとめたモデルです。ラフや線画から構図を渡したり、グレースケール画像を彩色できたりします。
+* この workflow では、入力画像から `Canny` で輪郭を抽出し、制御画像として使っています。

--- a/src/content/zh/basic-workflows/anima.md
+++ b/src/content/zh/basic-workflows/anima.md
@@ -42,6 +42,9 @@ hero:
 
   * [qwen_image_vae.safetensors](https://huggingface.co/circlestone-labs/Anima/blob/main/split_files/vae/qwen_image_vae.safetensors) (254 MB)
 
+> `anima-base-v1.0` 是未经调整的基础模型。
+> `anima-aesthetic-v1.1` 是使用高质量图像微调过的模型。如果只想轻松试试生成，基本上使用这个即可。
+
 ```text
 📂ComfyUI/
 └── 📂models/
@@ -81,7 +84,7 @@ masterpiece, best quality, score_9, safe,
 
 ## Anima LLLite
 
-LLLite 是 Kohya 开发的、类似轻量版 ControlNet 的技术。
+ControlNet-LLLite 是 kohya 开发的轻量级 ControlNet。
 
 ### 模型下载
 
@@ -89,7 +92,7 @@ LLLite 是 Kohya 开发的、类似轻量版 ControlNet 的技术。
 
 请根据要使用的控制图像准备合适的模型。
 
-> 标有 `v2` 的模型针对 Anima-Base v1.0 训练。本例将其与 `anima-aesthetic-v1.1` 搭配使用。其他模型使用旧版 Anima Preview3 训练，因此效果可能会稍弱一些。
+> 标有 `v2` 的模型针对 Anima-Base v1.0 训练。其他模型使用旧版 Anima Preview3 训练，因此效果可能会稍弱一些。
 
 ```text
 📂ComfyUI/
@@ -104,6 +107,5 @@ LLLite 是 Kohya 开发的、类似轻量版 ControlNet 的技术。
 
 [](/workflows/basic-workflows/anima/anima-lllite-any-test-like-v2.json)
 
-`any-test-like-v2` 把草图、线稿和灰度图等几种控制整合在一个模型里。
-
-这里先简单提取边缘，把结果作为输入来使用。
+* `anima-lllite-any-test-like-v2` 将多种控制整合在一个模型中。它可以通过草图或线稿传递构图，也可以为灰度图像上色。
+* 这个工作流会使用 `Canny` 从输入图像中提取轮廓，并将其作为控制图像。


### PR DESCRIPTION
## What changed
- Simplified the Japanese ControlNet-LLLite description and clarified the example workflow bullets.
- Synchronized the English and Simplified Chinese Anima pages with the Japanese source.
- Added the missing Base/Aesthetic model guidance to the translated pages.

## Why
Keep the LLLite explanation concise and keep all three language versions aligned.

## Impact
Documentation only. Workflow files and behavior are unchanged.

## Checks
- git diff --check
- npm run check
- npm run build

The checks pass with 76 existing link advisories and 22 existing icon advisories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the differences between Anima Base and the Aesthetic model.
  * Updated Anima LLLite guidance to describe its ControlNet-based controls and model compatibility.
  * Expanded workflow documentation covering composition control, grayscale coloring, and Canny-based outline extraction.
  * Updated English, Japanese, and Chinese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->