### PR TITLE
Update List node documentation

### DIFF
--- a/src/content/en/data-utilities/list.md
+++ b/src/content/en/data-utilities/list.md
@@ -5,8 +5,8 @@ section: data-utilities
 slug: list
 navId: list
 title: "List"
-created: 2025-11-27
-updated: 2026-03-02
+created: 2025-11-26
+updated: 2026-08-03
 summary: "Concept of continuous processing using multiple data"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:
@@ -28,31 +28,28 @@ It is easier to understand if you think of it as the difference between "Pressin
 
 ---
 
-## Required Custom Nodes
-
-Since standard ComfyUI nodes cannot create Lists, you need to introduce custom nodes.
-
-- [ltdrdata/ComfyUI-Impact-Pack](https://github.com/ltdrdata/ComfyUI-Impact-Pack)
-- [ltdrdata/ComfyUI-Inspire-Pack](https://github.com/ltdrdata/ComfyUI-Inspire-Pack)
-- [godmt/ComfyUI-List-Utils](https://github.com/godmt/ComfyUI-List-Utils)
-
----
-
 ## Creating a List
 
-### Make List (Any) Node
+### Create List Node
 
 This is a node for manually assembling a List.
 It groups any type (Image / Text / Number, etc.) into a single List.
 
-![](https://gyazo.com/b6433f5c097164a60a762e4cc24f442f){gyazo=image}
+![](https://gyazo.com/06892a5581ad86c9a2b56f01df91b983){gyazo=image}
 
-[](/workflows/data-utilities/list/Make_List_(Any).json)
+[](/workflows/data-utilities/list/Create_List.json)
 
 - Slots increase as you connect nodes, so you can add as many as you like.
-- Once connected, it is "fixed to that data type".
-  - If you want to switch to another data type, reset with Fix node (recreate) or place a new node.
 
+---
+
+## Useful Custom Nodes
+
+You can create a List using only standard ComfyUI nodes, but the available operations are limited. The following custom nodes let you create Lists from folders or strings and extract specific items from a List.
+
+- [ltdrdata/ComfyUI-Impact-Pack](https://github.com/ltdrdata/ComfyUI-Impact-Pack)
+- [ltdrdata/ComfyUI-Inspire-Pack](https://github.com/ltdrdata/ComfyUI-Inspire-Pack)
+- [godmt/ComfyUI-List-Utils](https://github.com/godmt/ComfyUI-List-Utils)
 
 ### Load Image List From Dir (Inspire) Node
 
@@ -78,10 +75,6 @@ Splits one long `STRING` with a delimiter and converts it to a List.
 - `delimiter`: Delimiter character (`,` might be better avoided as it is often used in prompts)
 - `splitlines`: Split by newlines
 - `strip` : Remove leading and trailing whitespace
-
----
-
-## Extracting from List
 
 ### Select Nth Item (Any list) Node
 

--- a/src/content/ja/data-utilities/list.md
+++ b/src/content/ja/data-utilities/list.md
@@ -6,7 +6,7 @@ slug: list
 navId: list
 title: "List"
 created: 2025-11-26
-updated: 2026-03-02
+updated: 2026-08-03
 summary: "複数データを使った連続処理の考え方"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:
@@ -27,31 +27,28 @@ Queue が「同じ workflow を何回も実行する」のに対し、List は *
 
 ---
 
-## 必要なカスタムノード
-
-ComfyUI の標準ノードだけでは List を作れないため、 カスタムノードを導入します。
-
-- [ltdrdata/ComfyUI-Impact-Pack](https://github.com/ltdrdata/ComfyUI-Impact-Pack)
-- [ltdrdata/ComfyUI-Inspire-Pack](https://github.com/ltdrdata/ComfyUI-Inspire-Pack)
-- [godmt/ComfyUI-List-Utils](https://github.com/godmt/ComfyUI-List-Utils)
-
----
-
 ## List を作る
 
-### Make List (Any) ノード
+### Create List ノード
 
 手動で List を組み立てるためのノードです。  
 任意の型（画像 / テキスト / 数値など）をまとめて 1 本の List にします。
 
-![](https://gyazo.com/b6433f5c097164a60a762e4cc24f442f){gyazo=image}
+![](https://gyazo.com/06892a5581ad86c9a2b56f01df91b983){gyazo=image}
 
-[](/workflows/data-utilities/list/Make_List_(Any).json)
+[](/workflows/data-utilities/list/Create_List.json)
 
 - ノードを接続するとスロットが増えるため、好きな数だけ追加できます。
-- 一度接続すると「そのデータ型で固定」されます。
-  - 他のデータ型に切り替える場合は、Fix node (recreate) でリセットするか、新しくノードを置いてください
 
+---
+
+## あると便利なカスタムノード
+
+List は ComfyUI の標準ノードだけでも作れますが、できることは限られています。以下のカスタムノードがあると、フォルダや文字列から List を作ったり、List から特定の要素を取り出したりできます。
+
+- [ltdrdata/ComfyUI-Impact-Pack](https://github.com/ltdrdata/ComfyUI-Impact-Pack)
+- [ltdrdata/ComfyUI-Inspire-Pack](https://github.com/ltdrdata/ComfyUI-Inspire-Pack)
+- [godmt/ComfyUI-List-Utils](https://github.com/godmt/ComfyUI-List-Utils)
 
 ### Load Image List From Dir (Inspire) ノード
 
@@ -77,10 +74,6 @@ ComfyUI の標準ノードだけでは List を作れないため、 カスタ�
 - `delimiter`：区切り文字（`,` はプロンプトで多用するため避けたほうが無難かもしれません）
 - `splitlines`：改行ごとに区切る
 - `strip` : 前後の空白を削除
-
----
-
-## Listから取り出す
 
 ### Select Nth Item (Any list) ノード
 

--- a/src/content/zh/data-utilities/list.md
+++ b/src/content/zh/data-utilities/list.md
@@ -5,8 +5,8 @@ section: data-utilities
 slug: list
 navId: list
 title: "List"
-created: 2026-02-06
-updated: 2026-03-02
+created: 2025-11-26
+updated: 2026-08-03
 summary: "关于列表：使用多个数据进行连续处理的思路"
 permalink: "/{{ lang }}/{{ section }}/{{ slug }}/"
 hero:
@@ -27,31 +27,28 @@ List（列表）是一种将多个数据作为“一个整体”来处理的机�
 
 ---
 
-## 必要的自定义节点
-
-仅靠 ComfyUI 的标准节点无法创建 List，因此需要引入自定义节点。
-
-- [ltdrdata/ComfyUI-Impact-Pack](https://github.com/ltdrdata/ComfyUI-Impact-Pack)
-- [ltdrdata/ComfyUI-Inspire-Pack](https://github.com/ltdrdata/ComfyUI-Inspire-Pack)
-- [godmt/ComfyUI-List-Utils](https://github.com/godmt/ComfyUI-List-Utils)
-
----
-
 ## 创建 List
 
-### Make List (Any) 节点
+### Create List 节点
 
 用于手动组装 List 的节点。
 将任意类型（图像 / 文本 / 数值等）汇总成 1 个 List。
 
-![](https://gyazo.com/b6433f5c097164a60a762e4cc24f442f){gyazo=image}
+![](https://gyazo.com/06892a5581ad86c9a2b56f01df91b983){gyazo=image}
 
-[](/workflows/data-utilities/list/Make_List_(Any).json)
+[](/workflows/data-utilities/list/Create_List.json)
 
 - 连接节点后插槽会增加，可以添加任意数量。
-- 一旦连接，就会被“固定为该数据类型”。
-  - 如果要切换到其他数据类型，请通过 Fix node (recreate) 重置，或放置新的节点。
 
+---
+
+## 方便使用的自定义节点
+
+仅使用 ComfyUI 的标准节点也可以创建 List，但能做的操作比较有限。使用以下自定义节点，可以从文件夹或字符串创建 List，也可以从 List 中取出指定元素。
+
+- [ltdrdata/ComfyUI-Impact-Pack](https://github.com/ltdrdata/ComfyUI-Impact-Pack)
+- [ltdrdata/ComfyUI-Inspire-Pack](https://github.com/ltdrdata/ComfyUI-Inspire-Pack)
+- [godmt/ComfyUI-List-Utils](https://github.com/godmt/ComfyUI-List-Utils)
 
 ### Load Image List From Dir (Inspire) 节点
 
@@ -78,13 +75,9 @@ List（列表）是一种将多个数据作为“一个整体”来处理的机�
 - `splitlines`：按换行符分割
 - `strip` : 删除前后的空白
 
----
-
-## 从 List 中取出
-
 ### Select Nth Item (Any list) 节点
 
-从 List 中只取出指定位置的用于 1 件。
+从 List 中取出指定位置的一个元素。
 
 ![](https://gyazo.com/f1d3281970effbc7a2fc8a782f1a21ab){gyazo=image}
 

--- a/src/workflows/data-utilities/list/Create_List.json
+++ b/src/workflows/data-utilities/list/Create_List.json
@@ -1,0 +1,267 @@
+{
+  "id": "21514ac1-a768-45b5-aad7-2f80aa417de2",
+  "revision": 0,
+  "last_node_id": 8,
+  "last_link_id": 10,
+  "nodes": [
+    {
+      "id": 8,
+      "type": "PreviewImage",
+      "pos": [
+        -439.6097220370311,
+        617.4692913742188
+      ],
+      "size": [
+        535.9982800174616,
+        483.16886172800355
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 7
+        }
+      ],
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.29.0",
+        "Node name for S&R": "PreviewImage"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 5,
+      "type": "LoadImage",
+      "pos": [
+        -1386.4004264825394,
+        617.4692913742188
+      ],
+      "size": [
+        222.798828125,
+        329.1218985681479
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            8
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.29.0",
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": [
+        "9af5807860cb17e45acaabd3556f09fc.png",
+        "image"
+      ]
+    },
+    {
+      "id": 6,
+      "type": "LoadImage",
+      "pos": [
+        -1147.3105999818763,
+        717.2786559338588
+      ],
+      "size": [
+        222.798828125,
+        329.1218985681479
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            9
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.29.0",
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": [
+        "a6e07600049875412da66a0ac4ca5351.png",
+        "image"
+      ]
+    },
+    {
+      "id": 7,
+      "type": "LoadImage",
+      "pos": [
+        -908.2207734812131,
+        819.0392260280028
+      ],
+      "size": [
+        222.798828125,
+        329.1218985681479
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            10
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.29.0",
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": [
+        "c4adc405e821b058ba473eb60387ea0f.png",
+        "image"
+      ]
+    },
+    {
+      "id": 1,
+      "type": "CreateList",
+      "pos": [
+        -619.6097220370318,
+        617.4692913742188
+      ],
+      "size": [
+        140,
+        86
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "input0",
+          "name": "inputs.input0",
+          "type": "IMAGE",
+          "link": 8
+        },
+        {
+          "label": "input1",
+          "name": "inputs.input1",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": 9
+        },
+        {
+          "label": "input2",
+          "name": "inputs.input2",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": 10
+        },
+        {
+          "label": "input3",
+          "name": "inputs.input3",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "list",
+          "shape": 6,
+          "type": "IMAGE",
+          "links": [
+            7
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.29.0",
+        "Node name for S&R": "CreateList"
+      },
+      "widgets_values": []
+    }
+  ],
+  "links": [
+    [
+      7,
+      1,
+      0,
+      8,
+      0,
+      "IMAGE"
+    ],
+    [
+      8,
+      5,
+      0,
+      1,
+      0,
+      "IMAGE"
+    ],
+    [
+      9,
+      6,
+      0,
+      1,
+      1,
+      "IMAGE"
+    ],
+    [
+      10,
+      7,
+      0,
+      1,
+      2,
+      "IMAGE"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.8471109211854292,
+      "offset": [
+        1750.4212728911962,
+        -190.47122876924507
+      ]
+    },
+    "frontendVersion": "1.47.11"
+  },
+  "version": 0.4
+}


### PR DESCRIPTION
## Summary
- replace the custom Make List example with ComfyUI core Create List
- reorganize optional custom List utilities under one section
- sync the Japanese, English, and Simplified Chinese pages
- add the downloadable Create List workflow

## Why
ComfyUI now provides a core Create List node, so the page should introduce the standard option first and present custom nodes as optional utilities.

## Checks
- git diff --check
- npm run check
- npm run build

## Advisories
- 73 existing link advisories
- 22 existing icon advisories
- Playwright not run because this change only affects article content and workflow JSON

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the List guide in English, Japanese, and Chinese with clearer instructions and refreshed metadata.
  * Added guidance for creating and reading Lists with standard and custom nodes.
  * Clarified how to select a specific item from a List and removed outdated instructions.

* **New Features**
  * Added a workflow example demonstrating how to combine images into a List and preview the results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->