### PR TITLE
Improve agent discovery signals

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -801,6 +801,13 @@ export default function (eleventyConfig) {
     return encodeURIComponent(String(value));
   });
 
+  eleventyConfig.addFilter("jsonLd", function (value = {}) {
+    return JSON.stringify(value)
+      .replace(/</g, "\\u003c")
+      .replace(/>/g, "\\u003e")
+      .replace(/&/g, "\\u0026");
+  });
+
   eleventyConfig.addShortcode("gyazoVideoLoop", function (url, caption = "", options = {}) {
     const id = extractGyazoId(url);
     const dims = getGyazoDimensionsFromId(id);

--- a/functions/api/contact.ts
+++ b/functions/api/contact.ts
@@ -18,7 +18,22 @@ function json(data: unknown, status = 200): Response {
   });
 }
 
-export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
+export const onRequest: PagesFunction<Env> = async ({ request, env }) => {
+  if (request.method !== "POST") {
+    return new Response(JSON.stringify({
+      ok: false,
+      error: "method_not_allowed",
+      message: "Only POST requests are accepted.",
+      resolution: "Submit the contact form as multipart/form-data with POST."
+    }), {
+      status: 405,
+      headers: {
+        "Allow": "POST",
+        "Content-Type": "application/json; charset=utf-8"
+      }
+    });
+  }
+
   try {
     const missingEnv = [
       !env.TURNSTILE_SECRET ? "TURNSTILE_SECRET" : "",

--- a/ops/adr/2026-05-01-agent-discovery-and-ai-crawl-policy.md
+++ b/ops/adr/2026-05-01-agent-discovery-and-ai-crawl-policy.md
@@ -30,3 +30,16 @@ The site is an Eleventy documentation site, not an authenticated API product or 
 - Discovery metadata stays honest about the site's actual capabilities.
 - WebMCP-capable browsers can use structured search without affecting normal browsers.
 - Cloudflare settings still need to be checked after deploy because managed robots features can override the origin `robots.txt`.
+
+## 2026-08-24 Amendment: Readiness signal corrections
+
+An external agent-readiness scan exposed several places where the site's existing public surfaces were difficult to identify from the root URL. The following corrections improve machine-readable access without changing the site's purpose:
+
+- Redirect `/` to the canonical Japanese entry page with a real HTTP 302 instead of relying on meta refresh or JavaScript.
+- Add explicit "when to use" guidance to `llms.txt`.
+- Publish `WebSite` and `WebPage` JSON-LD on normal content pages.
+- Give the 404 page recovery links to `sitemap.xml` and `llms.txt` while retaining a real HTTP 404 response.
+- Give every operation in the existing OpenAPI description a stable `operationId`.
+- Return a structured JSON 405 response, including `Allow: POST`, when `/api/contact` receives a non-POST request.
+
+These changes describe capabilities that already exist. The site will not add a developer portal, invented API versioning or rate-limit policies, or organization address/telephone data solely to satisfy a generic readiness score.

--- a/ops/requirements.md
+++ b/ops/requirements.md
@@ -70,6 +70,7 @@
   - Disable the submit button while sending, show localized success/error status, and reset the form on success.
 - Backend requirements (Cloudflare Pages Functions):
   - `functions/api/contact.ts` handles `POST /api/contact`.
+  - Non-POST requests to `/api/contact` return a structured JSON `405 Method Not Allowed` response with `Allow: POST`.
   - Validate `cf-turnstile-response` against Turnstile `siteverify` with `TURNSTILE_SECRET`.
   - Send validated messages via Resend using `RESEND_API_KEY`, `CONTACT_FROM_EMAIL`, `CONTACT_TO_EMAIL`.
 
@@ -168,4 +169,10 @@
 - AI crawler policy is permissive: allow crawling for search, AI input, and AI training unless a future owner directive narrows this policy.
 - Publish machine-readable discovery files under `/.well-known/` only when they describe real site capabilities; do not advertise protected APIs, OAuth issuers, or MCP servers that do not exist.
 - Prefer low-maintenance static discovery artifacts for this Eleventy site. Cloudflare-only features may be enabled operationally, but their intended behavior must be reflected here or in an ADR.
+- `/` must use a real HTTP redirect to the canonical Japanese entry page; meta refresh and JavaScript are fallback output only, not the public redirect mechanism.
+- `llms.txt` must state concrete situations in which an agent should use the site.
+- Normal content pages publish minimal `WebSite` + `WebPage` JSON-LD using their canonical URL, language, title, and summary.
+- The real 404 response must provide recovery links to `sitemap.xml` and `llms.txt`.
+- Every operation advertised by the public OpenAPI document must have a unique, stable `operationId`.
+- Do not invent developer portals, API lifecycle policies, business contact data, or rate-limit behavior solely to improve generic agent-readiness scores.
 - WebMCP support, when present, must be progressive enhancement only. If `navigator.modelContext` is unavailable, the site must behave exactly as before.

--- a/src/.well-known/openapi.json
+++ b/src/.well-known/openapi.json
@@ -13,6 +13,7 @@
   "paths": {
     "/search/index-ja.json": {
       "get": {
+        "operationId": "getJapaneseSearchIndex",
         "summary": "Japanese search index",
         "description": "Returns the static client-side search index for Japanese pages.",
         "responses": {
@@ -31,6 +32,7 @@
     },
     "/search/index-en.json": {
       "get": {
+        "operationId": "getEnglishSearchIndex",
         "summary": "English search index",
         "description": "Returns the static client-side search index for English pages.",
         "responses": {
@@ -49,6 +51,7 @@
     },
     "/search/index-zh.json": {
       "get": {
+        "operationId": "getChineseSearchIndex",
         "summary": "Chinese search index",
         "description": "Returns the static client-side search index for Chinese pages.",
         "responses": {
@@ -67,6 +70,7 @@
     },
     "/api/contact": {
       "post": {
+        "operationId": "submitContactMessage",
         "summary": "Submit a contact message",
         "description": "Accepts operator contact messages from the public contact page. Cloudflare Turnstile verification is required.",
         "requestBody": {

--- a/src/.well-known/openapi.json
+++ b/src/.well-known/openapi.json
@@ -131,7 +131,23 @@
             "description": "Invalid input"
           },
           "405": {
-            "description": "Unsupported method"
+            "description": "Unsupported method",
+            "headers": {
+              "Allow": {
+                "description": "The supported method for this endpoint.",
+                "schema": {
+                  "type": "string",
+                  "const": "POST"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MethodNotAllowedError"
+                }
+              }
+            }
           },
           "500": {
             "description": "Server error",
@@ -191,6 +207,32 @@
           "ok"
         ],
         "additionalProperties": true
+      },
+      "MethodNotAllowedError": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "const": false
+          },
+          "error": {
+            "type": "string",
+            "const": "method_not_allowed"
+          },
+          "message": {
+            "type": "string"
+          },
+          "resolution": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok",
+          "error",
+          "message",
+          "resolution"
+        ],
+        "additionalProperties": false
       },
       "ServerError": {
         "type": "object",

--- a/src/404.njk
+++ b/src/404.njk
@@ -12,4 +12,5 @@ hero:
 <div class="article-body placeholder">
   <h1>404</h1>
   <p>指定されたページは存在しません。サイドバーや About から別のトピックを選んでください。</p>
+  <p><a href="/sitemap.xml">サイトマップ</a>、または <a href="/llms.txt">AI・機械向けの記事一覧</a>から目的のページを探せます。</p>
 </div>

--- a/src/_redirects
+++ b/src/_redirects
@@ -1,3 +1,5 @@
+/ /ja/begin-with/how-to-use-this-site/ 302
+
 /ja/faq/duplicate-objects/ /ja/notes/duplicate-objects/ 301
 /ja/faq/error-handling/ /ja/notes/error-handling/ 301
 /ja/faq/import-failed/ /ja/notes/import-failed/ 301

--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -71,6 +71,30 @@ headingAnchorI18n.copiedLabel[site.defaultLang] or "Copied" -%}
   {% if ogImage %}
   <meta name="twitter:image" content="{{ ogImage | e }}" />
   {% endif %}
+  {% if canonicalUrl and pagePath != "/404.html" %}
+  {% set structuredData = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "WebSite",
+        "@id": siteUrl ~ "/#website",
+        "url": siteUrl ~ "/",
+        "name": site.name[currentLang] or site.name[site.defaultLang],
+        "inLanguage": currentLang
+      },
+      {
+        "@type": "WebPage",
+        "@id": canonicalUrl ~ "#webpage",
+        "url": canonicalUrl,
+        "name": title,
+        "description": pageSummary,
+        "inLanguage": currentLang,
+        "isPartOf": { "@id": siteUrl ~ "/#website" }
+      }
+    ]
+  } %}
+  <script type="application/ld+json">{{ structuredData | jsonLd | safe }}</script>
+  {% endif %}
   {% set langOptions = site.languages or [] -%}
   {% set currentSlug = currentNavId or slug -%}
 {% set isStandalone = (not sectionExists) and (currentSlug == 'news' or currentSlug == 'about' or currentSlug == 'contact') -%}

--- a/src/llms.njk
+++ b/src/llms.njk
@@ -21,6 +21,18 @@ Languages: {% for language in site.languages %}{{ language.code }}{% if not loop
 - Search index ZH: {{ site.url }}/search/index-zh.json
 - API catalog: {{ site.url }}/.well-known/api-catalog
 
+## When to use this site
+
+Use this site when an agent needs to:
+
+- explain how ComfyUI works or how to operate it;
+- find practical image, video, mask, data-processing, or API workflows;
+- compare ComfyUI techniques, models, nodes, and common troubleshooting approaches;
+- retrieve reproducible workflow JSON shown in an article;
+- answer in Japanese, English, or Chinese using a canonical documentation source.
+
+Japanese pages are the source of truth when localized pages differ. Link to the canonical article and do not invent workflow settings that are absent from the article or its JSON.
+
 ## Sections
 {% for section in site.sections %}
 

--- a/tests/layout.spec.ts
+++ b/tests/layout.spec.ts
@@ -6,6 +6,36 @@ const BASE_TEST_URL =
   process.env.PLAYWRIGHT_BASE_URL || `http://127.0.0.1:${PLAYWRIGHT_PORT}`;
 
 test.describe("Layout rails", () => {
+  test("content pages expose WebSite and WebPage JSON-LD", async ({ page }) => {
+    await page.goto("/ja/begin-with/how-to-use-this-site/");
+
+    const rawJsonLd = await page
+      .locator('script[type="application/ld+json"]')
+      .textContent();
+    const jsonLd = JSON.parse(rawJsonLd || "{}");
+
+    expect(jsonLd["@context"]).toBe("https://schema.org");
+    expect(jsonLd["@graph"]).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        "@type": "WebSite",
+        "@id": "https://comfyui.nomadoor.net/#website"
+      }),
+      expect.objectContaining({
+        "@type": "WebPage",
+        "url": "https://comfyui.nomadoor.net/ja/begin-with/how-to-use-this-site/",
+        "inLanguage": "ja"
+      })
+    ]));
+  });
+
+  test("404 page links agents back to discovery indexes", async ({ page }) => {
+    const response = await page.goto("/this-page-does-not-exist");
+
+    expect(response?.status()).toBe(404);
+    await expect(page.getByRole("link", { name: "サイトマップ" })).toHaveAttribute("href", "/sitemap.xml");
+    await expect(page.getByRole("link", { name: "AI・機械向けの記事一覧" })).toHaveAttribute("href", "/llms.txt");
+  });
+
   test("heading permalink icon copies the heading URL", async ({ page }) => {
     await page.addInitScript(() => {
       window.__copied = "";


### PR DESCRIPTION
## Summary

- replace the root meta-refresh-only entry with a real Cloudflare Pages 302 redirect
- add explicit llms.txt usage guidance and minimal WebSite/WebPage JSON-LD to content pages
- add agent recovery links to the 404 page and stable operationIds to the public OpenAPI document
- return structured JSON 405 responses with Allow: POST for non-POST contact requests
- document the scope: improve existing public signals without inventing developer-platform capabilities

## Why

The existing site already publishes robots.txt, llms.txt, an API catalog, OpenAPI, Agent Skills discovery, and AI-oriented response headers. A readiness review still treated the root meta-refresh stub as the site itself and could not reliably identify several existing surfaces. This PR corrects those concrete discovery gaps while keeping the site an Eleventy documentation site.

## Verification

- `git diff --check`
- `npm run check`
- `npm run build`
- `npm run test:playwright` (18 passed)
- Wrangler Pages local verification: `/` returned 302 with `Location`; GET/HEAD/OPTIONS `/api/contact` returned JSON 405 with `Allow: POST`

## Advisories

- 73 existing advisory link issues remain
- 22 existing advisory icon issues remain


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added structured JSON-LD metadata to content pages.
  - Added guidance for AI-readable site content and multilingual navigation.
  - Added sitemap and article-index links to 404 pages.
  - Added a permanent redirect for a moved Japanese help page.
  - Added clearer API method documentation and structured responses for unsupported requests.

- **Bug Fixes**
  - Improved contact API handling for non-POST requests with clear error responses.

- **Tests**
  - Added coverage for JSON-LD metadata and 404-page navigation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->